### PR TITLE
Fix arguments to TunnelZoneHost swapping third and fourth ones

### DIFF
--- a/src/midonetclient/tunnel_zone.py
+++ b/src/midonetclient/tunnel_zone.py
@@ -73,5 +73,5 @@ class TunnelZone(ResourceBase):
 
     def add_tunnel_zone_host(self):
         return TunnelZoneHost(self.dto['hosts'], {},
-                              self._get_tunnel_zone_host_media_type(),
-                              self.auth)
+                              self.auth,
+                              self._get_tunnel_zone_host_media_type())


### PR DESCRIPTION
It's just a trivial issue. The third and fourth arguments should be swapped.
