### PR TITLE
Correctly passes the query arg after re-login on 401.

### DIFF
--- a/src/midonetclient/api_lib.py
+++ b/src/midonetclient/api_lib.py
@@ -70,7 +70,7 @@ def do_request(uri, method, body=None, query=None, headers=None):
     LOG.debug("do_request: body=%s" % body)
     LOG.debug("do_request: headers=%s" % headers)
 
-    if query is not None:
+    if query:
         uri += '?' + urllib.urlencode(query)
     data = json.dumps(body) if body is not None else '{}'
     headers = headers or dict()

--- a/src/midonetclient/auth_lib.py
+++ b/src/midonetclient/auth_lib.py
@@ -103,4 +103,5 @@ class Auth:
         except exc.HTTPUnauthorized:
             # Try one more time after logging in
             self.set_header_token(headers, force=True)
-            return api_lib.do_request(uri, method, body=body, headers=headers)
+            return api_lib.do_request(uri, method, body=body, query=query,
+                                      headers=headers)


### PR DESCRIPTION
Change-Id: I29d9402732071550925c14231239a71ef1e982da

Fixes #23 

Fixes a bug where the query argument is lost after retrying authentication on login token expiration. Currently, when a login token expires, the authentication server such as Keystone returns 401 HTTPUnauthorized via Midonet API. The Python Midonet Client correctly handles the 401 and attemps re-authentication. However, after a successful re-authentication, it fails to pass on the original query parameters, which typically contain a tenant ID, etc. to the reissued REST request, thus the request resulting in a 400 Bad Request.
