### PR TITLE
Fix CLI's filename in python-midonetclient.install.

### DIFF
--- a/debian/python-midonetclient.install
+++ b/debian/python-midonetclient.install
@@ -1,2 +1,2 @@
 src/midonetclient usr/share/pyshared/
-src/bin/mn-ctl usr/bin
+src/bin/midonet-cli usr/bin


### PR DESCRIPTION
Signed-off-by: Jacob Mandelson jlm@midokura.com
