### PR TITLE
Packaging fixes.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,5 +12,6 @@ Vcs-Browser: https://github.com/midokura/python-midonetclient
 
 Package: python-midonetclient
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, python-webob, python-eventlet
+Depends: ${misc:Depends}, ${python:Depends}, python-webob, python-eventlet,
+ python-httplib2
 Description: Python client for MidoNet REST API.

--- a/rhel/copyright
+++ b/rhel/copyright
@@ -1,0 +1,23 @@
+This work was packaged for RPM by:
+
+    Guillermo Otañon <gotanon@midokura.com> on Mon, 19 Aug 2013 9:28:00 +0000
+
+It was downloaded from:
+
+    https://github.com/midokura/python-midonetclient
+
+Upstream Author(s):
+
+    Ryu Ishimoto <ryu@midokura.com>
+
+Copyright:
+
+    Copyright (C) 2013 Midokura KK
+
+License:
+
+    This work is proprietary software. All rights reserved.
+
+The RPM packaging is:
+
+    Copyright (C) 2013 Midokura KK

--- a/rhel/package.sh
+++ b/rhel/package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 version=`grep ^Version rhel/*.spec | cut -d ' ' -f 5`
-package=python-midonet-client
+package=python-midonetclient
 
 git archive HEAD --prefix=$package-$version/ -o /home/midokura/rpmbuild/SOURCES/$package-$version.tar
 gzip /home/midokura/rpmbuild/SOURCES/$package-$version.tar

--- a/rhel/python-midonetclient.spec
+++ b/rhel/python-midonetclient.spec
@@ -1,3 +1,8 @@
+# TODO:
+# -RONN documentation not built and installed.
+# -Man files not built and installed.
+# -Changelog.gz not installed.
+# -.pyc files not built and installed.
 Name:       python-midonetclient
 Epoch:      1
 Version:    1.2.0
@@ -6,9 +11,14 @@ Summary:    Python client for MidoNet REST API.
 Group:      Development/Languages
 License:    Test
 URL:        https://github.com/midokura/midonet-client
-Source0:    https://github.com/midokura/midonet-client/python-midonet-client-%{version}.tar.gz
+Source0:    https://github.com/midokura/midonet-client/python-midonetclient-%{version}.tar.gz
 BuildArch:  noarch
 BuildRoot:  /var/tmp/%{name}-buildroot
+# I added this line but then had to comment it out to build on Ubuntu,
+# since rpm doesn't know about packages installed via dpkg. Leaving it
+# commented out until someone can test on an RPM system.
+# BuildRequires: python, python-support, python-unittest2, python-all-dev, ruby-ronn
+Requires:   python-webob, python-eventlet, python-httplib2
 
 %description
 Python client for MidoNet REST API.
@@ -18,11 +28,18 @@ Python client for MidoNet REST API.
 
 %install
 mkdir -p $RPM_BUILD_ROOT/%{python_sitelib}
-cp -r src/midonetclient/ $RPM_BUILD_ROOT/%{python_sitelib}/ 
+mkdir -p $RPM_BUILD_ROOT/%{_bindir}
+mkdir -p $RPM_BUILD_ROOT/%{_docdir}/%{name}
+cp -r src/midonetclient/ $RPM_BUILD_ROOT/%{python_sitelib}/
+cp -r src/bin/midonet-cli $RPM_BUILD_ROOT/%{_bindir}/
+cp -r rhel/copyright $RPM_BUILD_ROOT/%{_docdir}/%{name}/
+cp -r README $RPM_BUILD_ROOT/%{_docdir}/%{name}/
 
 %files
 %defattr(-,root,root)
 %{python_sitelib}/midonetclient
+%{_bindir}/midonet-cli
+%{_docdir}/%{name}
 
 %changelog
 * Thu Aug 8 2013 Guillermo Ontanon <guillermo@midokura.com> - 1.1.0-1.0


### PR DESCRIPTION
-Add dependency on python-httplib2.
-Add dependencies to RPM package.
-Add copyright and README files to RPM package.
-Add midonet-cli to RPM package.

Fixes MN-279

Signed-off-by: Brandon Berg bberg@midokura.jp
