### PR TITLE
Remove dependencies to fix CentOS install

### DIFF
--- a/rhel/python-midonetclient.spec
+++ b/rhel/python-midonetclient.spec
@@ -18,7 +18,9 @@ BuildRoot:  /var/tmp/%{name}-buildroot
 # since rpm doesn't know about packages installed via dpkg. Leaving it
 # commented out until someone can test on an RPM system.
 # BuildRequires: python, python-support, python-unittest2, python-all-dev, ruby-ronn
-Requires:   python-webob, python-eventlet, python-httplib2
+# Commented these out because they work in RHEL but CentOS still hasn't
+# got those packages available.
+# Requires: python >= 2.6, python-webob, python-eventlet, python-httplib2
 
 %description
 Python client for MidoNet REST API.


### PR DESCRIPTION
Also includes explicit python >= 2.6 dep. since we noticed that building
on a system with 2.7 includes this one by default, and CentOS doesn't
have packages for 2.7 so it breaks the build again. If it is ever
re-enabled it'll be safe already.

Fixes MN-297
Signed-off-by: Galo Navarro galo@midokura.com
