### PR TITLE
Remove port type from docs and comments

### DIFF
--- a/doc/cli-design.md
+++ b/doc/cli-design.md
@@ -89,7 +89,7 @@ class Bridge(ObjectType):
                                  element_type = BridgePort,                       
                                  list_method = 'get_ports',                       
                                  getter = 'get_port',                             
-                                 factory_method = 'add_interior_port'))           
+                                 factory_method = 'add_port'))           
         self.put_attr(SingleAttr(name = 'name',                                   
                                  value_type = StringType(),                       
                                  setter = 'name',                                 

--- a/doc/midonet-cli-bridge.1.ronn
+++ b/doc/midonet-cli-bridge.1.ronn
@@ -5,7 +5,7 @@ midonet-cli-bridge(1) -- Bridge objects in midonet-cli
 
     midonet> bridge list
     midonet> bridge create name demo
-    midonet> bridge bridge0 add port type exterior
+    midonet> bridge bridge0 add port
     midonet> bridge bridge0 list port
     midonet> bridge bridge0 add dhcp gw 203.0.113.1 subnet 203.0.113.0/24
     midonet> bridge bridge0 dhcp subnet 203.0.113.0/24 add host name HostName \ 
@@ -52,12 +52,11 @@ Attributes:
 
 Attributes:
 
-  * `type` `interior`|`exterior`
   * `device` <BRIDGE>
   * `infilter` <CHAIN>
   * `outfilter` <CHAIN>
   * `vlan` <VLAN_ID>
-  * `peer` <PORT> (interior ports only)
+  * `peer` <PORT>
 
 ## COPYRIGHT
 

--- a/doc/midonet-cli-router.1.ronn
+++ b/doc/midonet-cli-router.1.ronn
@@ -5,8 +5,7 @@ midonet-cli-router(1) -- Router objects in midonet-cli
 
     midonet> router list
     midonet> router create name demo
-    midonet> router router0 add port type exterior address 192.0.2.1 \
-             net 192.0.2.0/24
+    midonet> router router0 add port address 192.0.2.1 net 192.0.2.0/24
     midonet> router router0 list port<br>
     midonet> router router0 port port0 add bgp peer 192.0.2.2 \ 
              local-AS 1 peer-AS 2
@@ -44,14 +43,13 @@ Attributes:
 
 Attributes:
 
-  * `type` `interior`|`exterior`
   * `device` <ROUTER>
   * `infilter` <CHAIN>
   * `outfilter` <CHAIN>
   * `mac` <MAC_ADDRESS>
   * `address` <IP_ADDRESS>
   * `net` <CIDR>
-  * `peer` <PORT> (interior ports only)
+  * `peer` <PORT>
 
 Children object collections:
 

--- a/doc/midonet-cli.1.ronn
+++ b/doc/midonet-cli.1.ronn
@@ -7,7 +7,7 @@ midonet-cli(1) -- MidoNet command line interface
 `midonet-cli`<br>
 midonet> list bridge<br>
 midonet> create bridge name demo<br>
-midonet> bridge bridge0 add port type exterior<br>
+midonet> bridge bridge0 add port<br>
 midonet> delete bridge bridge0 port port0<br>
 midonet> exit
 
@@ -99,17 +99,17 @@ needed:
 
   * Listing the ports in a router:
     midonet> router router1 list port<br>
-    port port0 type exterior device router1 mac 02:d6:2b:08:85:6f \ <br>
-    address 192.0.2.1 net 192.0.2.0/24 <br>
-    port port1 type interior device router1 mac 02:78:16:e6:00:8a \ <br>
-    address 203.0.113.1 net 203.0.113.0/24 peer bridge0:port0
+    port port0 device router1 mac 02:d6:2b:08:85:6f address 192.0.2.1 \ <br>
+    net 192.0.2.0/24 <br>
+    port port1 device router1 mac 02:78:16:e6:00:8a address 203.0.113.1 \ <br>
+    net 203.0.113.0/24 peer bridge0:port0
 
   * The same command, using the UUID instead of the router alias:
     midonet> router 74b32ca0-cc7f-4d17-8547-efa5f1fada54 list port<br>
-    port port0 type exterior device router1 mac 02:d6:2b:08:85:6f \ <br>
-    address 192.0.2.1 net 192.0.2.0/24<br>
-    port port1 type interior device router1 mac 02:78:16:e6:00:8a \ <br>
-    address 203.0.113.1 net 203.0.113.0/24 peer bridge0:port0
+    port port0 device router1 mac 02:d6:2b:08:85:6f address 192.0.2.1 \ <br>
+    net 192.0.2.0/24<br>
+    port port1 device router1 mac 02:78:16:e6:00:8a address 203.0.113.1 \ <br>
+    net 203.0.113.0/24 peer bridge0:port0
 
 Aliases for children are scoped to their parent object. In this case, a port's
 alias is scoped within its parent router, thus there could be a <router0:port0>

--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -1363,8 +1363,7 @@ class AdRoute(ObjectType):
 class Router(ObjectType):
     def __init__(self, obj):
         ObjectType.__init__(self, obj)
-        # NOTE: factory method is a hack, the type attribute may later change
-        # the port type to exterior.
+        
         self.put_attr(TenantAttr())
         self.put_attr(Collection(name = 'port',
                                  element_type = RouterPort,
@@ -2850,7 +2849,7 @@ class Create(Command):
 
     Examples:
            create router name 'new router'
-           router router0 add port type interior address 1.1.1.1 net 1.1.1.0/24
+           router router0 add port address 1.1.1.1 net 1.1.1.0/24
            """
 
     def name(self):


### PR DESCRIPTION
Cleaning up the documentation to reflect the changes the team has made to remove interior/exterior port types
