### PR TITLE
CLI exits on first command when a credential is invalid.

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -3325,6 +3325,11 @@ class MidonetCLI(cmd.Cmd):
             if session.debug:
                 print 'Caught HTTPUnauthorized: %s' % str(err)
             return True
+        except socket.error as err:
+            print "Connection to MidoNet API server refused.\nBye."
+            if session.debug:
+                print 'Caught socket.error: %s' % str(err)
+            return True
         except Exception as e:
             import traceback
             if session.debug:
@@ -3400,8 +3405,8 @@ if __name__ == '__main__':
             cli.onecmd(session.command)
         else:
             # Test the credential by running a sample command first before
-            # starting a command loop.
-            if not cli.onecmd('list host'): cli.cmdloop()
+            # starting a command loop. The output won't be shown on the screen.
+            if not cli.onecmd('list tunnel-zone'): cli.cmdloop()
         sys.exit(0 if cli.last_command_succeeded else 1)
     except Exception as e:
         sys.stderr.write(e.message + "\n")

--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -24,6 +24,7 @@ import readline
 import socket
 import sys
 from shlex import split as shsplit
+from webob import exc
 
 from midonetclient.api import MidonetApi
 
@@ -3319,6 +3320,11 @@ class MidonetCLI(cmd.Cmd):
                 print result.describe()
             else:
                 print ParsingSubmatch(context).describe()
+        except exc.HTTPUnauthorized as err:
+            print "Invalid credential. Wrong username/password.\nBye."
+            if session.debug:
+                print 'Caught HTTPUnauthorized: %s' % str(err)
+            return True
         except Exception as e:
             import traceback
             if session.debug:

--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -3325,6 +3325,11 @@ class MidonetCLI(cmd.Cmd):
             if session.debug:
                 print 'Caught HTTPUnauthorized: %s' % str(err)
             return True
+        except socket.error as err:
+            print "Connection to MidoNet API server refused.\nBye."
+            if session.debug:
+                print 'Caught socket.error: %s' % str(err)
+            return True
         except Exception as e:
             import traceback
             if session.debug:
@@ -3401,7 +3406,7 @@ if __name__ == '__main__':
         else:
             # Test the credential by running a sample command first before
             # starting a command loop.
-            if not cli.onecmd('list host'): cli.cmdloop()
+            if not cli.onecmd('list tunnel-zone'): cli.cmdloop()
         sys.exit(0 if cli.last_command_succeeded else 1)
     except Exception as e:
         sys.stderr.write(e.message + "\n")

--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -24,6 +24,7 @@ import readline
 import socket
 import sys
 from shlex import split as shsplit
+from webob import exc
 
 from midonetclient.api import MidonetApi
 
@@ -3319,6 +3320,11 @@ class MidonetCLI(cmd.Cmd):
                 print result.describe()
             else:
                 print ParsingSubmatch(context).describe()
+        except exc.HTTPUnauthorized as err:
+            print "Invalid credential. Wrong username/password.\nBye."
+            if session.debug:
+                print 'Caught HTTPUnauthorized: %s' % str(err)
+            return True
         except Exception as e:
             import traceback
             if session.debug:
@@ -3393,7 +3399,9 @@ if __name__ == '__main__':
         if session.do_eval:
             cli.onecmd(session.command)
         else:
-            cli.cmdloop()
+            # Test the credential by running a sample command first before
+            # starting a command loop.
+            if not cli.onecmd('list host'): cli.cmdloop()
         sys.exit(0 if cli.last_command_succeeded else 1)
     except Exception as e:
         sys.stderr.write(e.message + "\n")


### PR DESCRIPTION
Currently CLI goes back to a normal command line loop showing a
prompt even when a previous command failed because of an invalid
credential. This is confusing as it can appear as if authentication
was successful and CLI was ready to take commands. The new behavior
is that CLI will exit upon a first command if a credential is
invalid, displaying a corresponding error message.

Fix MN-718

Change-Id: I2ceb940f35c7418edee3601a7fc55874e24436dd
