### PR TITLE
Add the setuptools package configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ debian/*.log
 debian/*.substvars
 debian/python-midonetclient/
 doc/*.1
+build/*
+dist/*
+src/*.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include README
+include LICENSE
+include LICENSE.mn-ctl
+include NEWS
+include MANIFEST.in
+recursive-include doc *
+recursive-include src *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license-file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2014 Midokura Europe SARL, All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+import sys
+from setuptools import setup, find_packages
+
+SRC_DIR = "src"
+MODULE_NAME = "midonetclient"
+
+# Prepend the directory which contains the module to `PYTHONPATH` temporarily.
+sys.path.insert(
+    0, '/'.join([os.path.dirname(os.path.abspath(__file__)), SRC_DIR]))
+
+def _readme():
+    with open("README") as f:
+        return f.read()
+
+setup(name=MODULE_NAME,
+      version=__import__(MODULE_NAME).__version__,
+      description="Midonet API client library for Python applications",
+      long_description=_readme(),
+      classifiers=[
+          "Development Status :: 4 - Beta",
+          "Intended Audience :: Developers",
+          "Intended Audience :: System Administrators",
+          "Intended Audience :: Telecommunications Industry",
+          "License :: OSI Approved :: Apache Software License",
+          "Topic :: System :: Networking",
+          "Topic :: System :: Shells",
+          "Topic :: Utilities",
+          ],
+      keywords="MidoNet midonetclient python-midonetclient",
+      author="Midokura Engineers",
+      author_email="dev@midokura.com",
+      url="https://github.com/midokura/python-midonetclient",
+      include_package_data=True,
+      package_dir={"": SRC_DIR},
+      packages=find_packages(SRC_DIR, exclude=["tests"]),
+      scripts=["src/bin/midonet-cli"],
+      install_requires=[
+          "webob",
+          "httplib2",
+          ],
+      zip_safe=False,
+      tests_require=["nose"],
+      test_suite="nose.collector",
+      license="Apache License, Version 2.0")

--- a/src/midonetclient/__init__.py
+++ b/src/midonetclient/__init__.py
@@ -17,3 +17,7 @@
 #
 # @author: Tomoe Sugihara <tomoe@midokura.com>, Midokura
 # @author: Ryu Ishimoto <ryu@midokura.com>, Midokura
+
+# The following version number is following the PEP 396:
+#   http://www.python.org/dev/peps/pep-0396/
+__version__ = "master"


### PR DESCRIPTION
Currently we can only use the debian package or the RPM package to
install python-midonetclient. It's not a trivial process to create these
packages and that makes adding new features harder. And it's not easy to
try this package out on Mac OSX.

This patch addds the setuptools package configuration, which makes us to
install python-midonetclient easier. We can also use virtualenv/venv to
separate the installation environments out from each other.

Because python-midonetclient is a public project, we can register this module
on PyPI. Feel free to register with the following command:

```
$ python setup.py register
```

Signed-off-by: Taku Fukushima tfukushima@midokura.com
