### PR TITLE
Release v1.3.0-rc4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-midonetclient (1.3.0~rc4) UNRELEASED; urgency=low
+
+  * 1.3.0~rc4
+
+ -- Ryu Ishimoto <ryu@ryu-ubuntu>  Sat, 18 Jan 2014 15:02:52 +0900
+
 python-midonetclient (1.3.0~rc3) precise; urgency=low
 
   * 1.3.0~rc3

--- a/rhel/python-midonetclient.spec
+++ b/rhel/python-midonetclient.spec
@@ -6,7 +6,7 @@
 Name:       python-midonetclient
 Epoch:      1
 Version:    1.3.0
-Release:    0.1.rc3
+Release:    0.1.rc4
 Summary:    Python client for MidoNet REST API.
 Group:      Development/Languages
 License:    Test


### PR DESCRIPTION
Release v1.3.0-rc4 which contains the fix for
BGP netlink error.

Signed-off-by: Ryu Ishimoto ryu@midokura.com
