### PR TITLE
Clean up port group apis

### DIFF
--- a/src/midonetclient/api.py
+++ b/src/midonetclient/api.py
@@ -316,7 +316,7 @@ class MidonetApi(object):
         route = router.add_route().type(type)
         route = route.src_network_addr(src_network_addr).src_network_length(
             src_network_length).dst_network_addr(
-                dst_network_addr).dst_network_length(dst_network_length)
+            dst_network_addr).dst_network_length(dst_network_length)
         route = route.next_hop_port(next_hop_port).next_hop_gateway(
             next_hop_gateway).weight(weight)
 
@@ -492,26 +492,10 @@ if __name__ == '__main__':
 
     # Routers/Ports
 
-    # port group1
-    pg1 = api.add_port_group().tenant_id(tenant_id).name('pg-1').create()
-    pg2 = api.add_port_group().tenant_id(tenant_id).name('pg-2').create()
-
-    # Tenant port groups
-    print '-------- Tenant port groups ------'
-    for t in tenants:
-        for p in t.get_port_groups():
-            print 'id: ',  p.get_id()
-
     rp1 = router1.add_port()\
                  .port_address('2.2.2.2')\
                  .network_address('2.2.2.0')\
                  .network_length(24).create()
-
-    # Add this port to both port groups
-    pgp1 = pg1.add_port_group_port().port_id(rp1.get_id()).create()
-    pgp2 = pg2.add_port_group_port().port_id(rp1.get_id()).create()
-    print 'rp1 port group ids=%r' % [pgp1.get_port_group_id(),
-                                     pgp2.get_port_group_id()]
 
     rp2 = router1.add_port().port_address('1.1.1.1')\
                  .network_address('1.1.1.0').network_length(24).create()
@@ -623,12 +607,6 @@ if __name__ == '__main__':
     # Bridges/Ports
     bp1 = bridge1.add_port().inbound_filter_id(random_uuid).create()
 
-    # Add this port to both port groups
-    pgp1 = pg1.add_port_group_port().port_id(bp1.get_id()).create()
-    pgp2 = pg2.add_port_group_port().port_id(bp1.get_id()).create()
-    print 'bp1 port group ids=%r' % [pgp1.get_port_group_id(),
-                                     pgp2.get_port_group_id()]
-
     bp2 = bridge1.add_port().create()
 
     print api.get_port(bp1.get_id())
@@ -658,31 +636,6 @@ if __name__ == '__main__':
         print 'dhcp subnet', ds
 
     bridge1.get_dhcp_subnet('11.11.11.0_24')
-
-    # list port groups and remove them.
-    pgs = api.get_port_groups({'tenant_id': tenant_id})
-    for pg in pgs:
-        print pg.get_name()
-        print pg.get_id()
-
-    # Add a port(bp2) to pg2
-    pgp1 = pg2.add_port_group_port().port_id(bp2.get_id()).create()
-
-    membership = pg2.get_ports()
-    size = len(membership)
-    print 'pg2(id=%r) membership=%r, size=%d' % (pg2.get_id(), membership,
-                                                 size)
-    pgp1.delete()
-    membership = pg2.get_ports()
-    size_after_delete_pgp1 = len(membership)
-    print 'pg2(id=%r) membership=%r, size=%d' % (pg2.get_id(),
-                                                 membership,
-                                                 size_after_delete_pgp1)
-    assert size == size_after_delete_pgp1 + 1
-
-    pg1.delete()
-    # Try deleting by ID
-    api.delete_port(pg2.get_id())
 
     # tear down routers and bridges
     bp2.unlink()    # if I don't unlink, deletion of router blows up

--- a/src/midonetclient/exc.py
+++ b/src/midonetclient/exc.py
@@ -30,10 +30,10 @@ def get_exception(status_code):
 
 
 class MidoApiConnectionError(Exception):
-	pass
+    pass
 
 
 class MidoApiConnectionRefused(MidoApiConnectionError):
-	def __init__(self):
-		MidoApiConnectionError.__init__(self,
-			"Could not connect to the midonet-api.")
+    def __init__(self):
+        MidoApiConnectionError.__init__(
+            self, "Could not connect to the midonet-api.")

--- a/src/midonetclient/host_version.py
+++ b/src/midonetclient/host_version.py
@@ -19,6 +19,7 @@
 from midonetclient import vendor_media_type
 from midonetclient.resource_base import ResourceBase
 
+
 class HostVersion(ResourceBase):
 
     media_type = vendor_media_type.APPLICATION_HOST_VERSION_JSON
@@ -38,7 +39,9 @@ class HostVersion(ResourceBase):
     # only get is supported for HostVersion
     def update(self, headers=None):
         raise AttributeError
+
     def create(self, headers=None):
         raise AttributeError
+
     def delete(self, headers=None):
         raise AttributeError

--- a/src/midonetclient/rule.py
+++ b/src/midonetclient/rule.py
@@ -60,11 +60,8 @@ class Rule(ResourceBase):
     def is_inv_out_ports(self):
         return self.dto['invOutPorts']
 
-    def is_inv_port_group_dst(self):
-        return self.dto['invPortGroupDst']
-
-    def is_inv_port_group_src(self):
-        return self.dto['invPortGroupSrc']
+    def is_inv_port_group(self):
+        return self.dto['invPortGroup']
 
     def is_inv_ip_addr_group_dst(self):
         return self.dto['invIpAddrGroupDst']
@@ -135,11 +132,8 @@ class Rule(ResourceBase):
     def get_out_ports(self):
         return self.dto['outPorts']
 
-    def get_port_group_dst(self):
-        return self.dto['portGroupDst']
-
-    def get_port_group_src(self):
-        return self.dto['portGroupSrc']
+    def get_port_group(self):
+        return self.dto['portGroup']
 
     def get_ip_addr_group_dst(self):
         return self.dto['ipAddrGroupDst']
@@ -162,12 +156,8 @@ class Rule(ResourceBase):
     def get_type(self):
         return self.dto['type']
 
-    def inv_port_group_dst(self, inv_port_group_dst):
-        self.dto['invPortGroupDst'] = inv_port_group_dst
-        return self
-
-    def inv_port_group_src(self, inv_port_group_src):
-        self.dto['invPortGroupSrc'] = inv_port_group_src
+    def inv_port_group(self, inv_port_group):
+        self.dto['invPortGroup'] = inv_port_group
         return self
 
     def inv_ip_addr_group_dst(self, inv_ip_addr_group_dst):
@@ -234,12 +224,8 @@ class Rule(ResourceBase):
         self.dto['invNwTos'] = inv_nw_tos
         return self
 
-    def port_group_dst(self, port_group_dst):
-        self.dto['portGroupDst'] = port_group_dst
-        return self
-
-    def port_group_src(self, port_group_src):
-        self.dto['portGroupSrc'] = port_group_src
+    def port_group(self, port_group):
+        self.dto['portGroup'] = port_group
         return self
 
     def ip_addr_group_dst(self, ip_addr_group_dst):

--- a/src/midonetclient/system_state.py
+++ b/src/midonetclient/system_state.py
@@ -20,6 +20,7 @@
 from midonetclient import vendor_media_type
 from midonetclient.resource_base import ResourceBase
 
+
 class SystemState(ResourceBase):
 
     media_type = vendor_media_type.APPLICATION_SYSTEM_STATE_JSON
@@ -40,4 +41,3 @@ class SystemState(ResourceBase):
     def availability(self, availability):
         self.dto['availability'] = availability
         return self
-

--- a/src/midonetclient/write_version.py
+++ b/src/midonetclient/write_version.py
@@ -20,6 +20,7 @@
 from midonetclient import vendor_media_type
 from midonetclient.resource_base import ResourceBase
 
+
 class WriteVersion(ResourceBase):
 
     media_type = vendor_media_type.APPLICATION_WRITE_VERSION_JSON
@@ -33,4 +34,3 @@ class WriteVersion(ResourceBase):
     def version(self, version):
         self.dto['version'] = version
         return self
-


### PR DESCRIPTION
- change port_group_src and port_group_dst to the single port_group.
- This is in line with what the midonet-api supports.

Signed-off-by: Joe Mills joe@midokura.com
