### PR TITLE
Fix return value of TunnelZone.type()

### DIFF
--- a/src/midonetclient/tunnel_zone.py
+++ b/src/midonetclient/tunnel_zone.py
@@ -64,7 +64,7 @@ class TunnelZone(ResourceBase):
 
     def type(self, type_):
         self.dto['type'] = type_
-        return self.dto['type']
+        return self
 
     def get_id(self):
         return self.dto['id']


### PR DESCRIPTION
This fixes the return value of type() method in TunnelZone class,
which is a setter and is supporsed to return self where it was
returning a value in DTO as getters do.
