### PR TITLE
Fix bugs in HealthMonitor and PoolMember

### DIFF
--- a/src/midonetclient/health_monitor.py
+++ b/src/midonetclient/health_monitor.py
@@ -35,6 +35,9 @@ class HealthMonitor(ResourceBase, AdminStateUpMixin):
     def get_timeout(self):
         return self.dto['timeout']
 
+    def get_type(self):
+        return self.dto['type']
+
     def get_max_retries(self):
         return self.dto['maxRetries']
 
@@ -55,6 +58,10 @@ class HealthMonitor(ResourceBase, AdminStateUpMixin):
 
     def timeout(self, timeout):
         self.dto['timeout'] = timeout
+        return self
+
+    def type(self, t):
+        self.dto['type'] = t
         return self
 
     def max_retries(self, max_retries):


### PR DESCRIPTION
This patch adds the missing `type` property for HealthMonitor and fixes
the typo of PoolMember's `weight` property.

Signed-off-by: Taku Fukushima tfukushima@midokura.com
