### PR TITLE
Remove packet tracing doc referencing from debian

### DIFF
--- a/debian/python-midonetclient.manpages
+++ b/debian/python-midonetclient.manpages
@@ -3,6 +3,5 @@ doc/midonet-cli-chain.1
 doc/midonet-cli-host.1
 doc/midonet-cli-port-group.1
 doc/midonet-cli-router.1
-doc/midonet-cli-trace-condition.1
 doc/midonet-cli-tunnel-zone.1
 doc/midonet-cli.1

--- a/debian/rules
+++ b/debian/rules
@@ -20,4 +20,3 @@ override_dh_auto_build:
 	ronn < doc/midonet-cli-host.1.ronn > doc/midonet-cli-host.1
 	ronn < doc/midonet-cli-tunnel-zone.1.ronn > doc/midonet-cli-tunnel-zone.1
 	ronn < doc/midonet-cli-port-group.1.ronn > doc/midonet-cli-port-group.1
-	ronn < doc/midonet-cli-trace-condition.1.ronn > doc/midonet-cli-trace-condition.1


### PR DESCRIPTION
Since packet tracing has been removed from the API, remove the
references to its manpage from the debian rule

Signed-off-by: Ryu Ishimoto ryu@midokura.com
