### PR TITLE
Add type property to HealthMonitor in the CLI

### DIFF
--- a/doc/midonet-cli-health-monitor.1.ronn
+++ b/doc/midonet-cli-health-monitor.1.ronn
@@ -4,11 +4,11 @@ midonet-cli-health-monitor(1) -- Health Monitor object in midonet-cli
 ## SYNOPSIS
 
     midonet> health-monitor list
-    midonet> health-monitor create delay 100 max-retries 50 timeout 500
+    midonet> health-monitor create delay 100 max-retries 50 timeout 500 type TCP
     hm0
     midonet> load-balancer lb0 pool pool0 set health-monitor hm0
     midonet> load-balancer lb0 pool pool0 health-monitor show
-    hm hm0 delay 100 timeout 500 max-retries 50 state down
+    hm hm0 delay 100 timeout 500 max-retries 50 state up type TCP
     midonet> health-monitor hm0 pool list
     pool pool0 load-balancer lb0 health-monitor hm0 lb-method ROUND_ROBIN \
         state up

--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -2142,15 +2142,14 @@ class HealthMonitor(ObjectType):
                                      setter = 'admin_state_up'))
         self.put_attr(EnumAttr(name = 'status',
                                mappings = {'ACTIVE': 'ACTIVE',
-                                           'DOWN': 'DOWN',
-                                           'PENDING_CREATE': 'PENDING_CREATE',
-                                           'PENDING_UPDATE': 'PENDING_UPDATE',
-                                           'PENDING_DELETE': 'PENDING_DELETE',
-                                           'INACTIVE': 'INACTIVE',
-                                           'ERROR': 'ERROR'},
+                                           'INACTIVE': 'INACTIVE'},
                                getter = 'get_status',
                                setter = 'status',
                                writeable = False))
+        self.put_attr(EnumAttr(name = 'type',
+                               mappings = {'TCP': 'TCP'},
+                               getter = 'get_type',
+                               setter = 'type'))
         self.put_attr(Collection(name = 'pool',
                                  element_type = Pool,
                                  list_method = 'get_pools',


### PR DESCRIPTION
This patch adds the missing type property which causes the Bad Request
errors when the new health monitors are posted.

This fixes [MN-1582](https://midobugs.atlassian.net/browse/MN-1582).

Signed-off-by: Taku Fukushima tfukushima@midokura.com
