### PR TITLE
Add protocol property to Pool

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -2065,6 +2065,11 @@ class Pool(ObjectType):
                                getter = 'get_lb_method',
                                setter = 'lb_method',
                                optional = False))
+        self.put_attr(EnumAttr(name = 'protocol',
+                               mappings = {'TCP': 'TCP'},
+                               getter = 'get_protocol',
+                               setter = 'protocol',
+                               writeable = False))
         self.put_attr(Collection(name = 'member',
                                  element_type = PoolMember,
                                  list_method = 'get_pool_members',

--- a/src/midonetclient/pool.py
+++ b/src/midonetclient/pool.py
@@ -39,6 +39,9 @@ class Pool(ResourceBase, AdminStateUpMixin):
     def get_health_monitor_id(self):
         return self.dto['healthMonitorId']
 
+    def get_protocol(self):
+        return self.dto['protocol']
+
     def get_pool_members(self, query=None):
         headers = {'Accept':
                    vendor_media_type.APPLICATION_POOL_MEMBER_COLLECTION_JSON}
@@ -66,6 +69,10 @@ class Pool(ResourceBase, AdminStateUpMixin):
 
     def health_monitor_id(self, health_monitor_id):
         self.dto['healthMonitorId'] = health_monitor_id
+        return self
+
+    def protocol(self, protocol):
+        self.dto['protocol'] = protocol
         return self
 
     def add_pool_member(self):


### PR DESCRIPTION
This patch adds the missing `protocol` property to Pool. The
`protocol` property is the read-only property and only "TCP" is
supported for now.

Signed-off-by: Taku Fukushima tfukushima@midokura.com
