### PR TITLE
remove use of deprecated exception member

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -3859,5 +3859,5 @@ if __name__ == '__main__':
             cli.cmdloop()
         sys.exit(0 if cli.last_command_succeeded else 1)
     except Exception as e:
-        sys.stderr.write(e.message + "\n")
+        sys.stderr.write(str(e) + "\n")
         sys.exit(2)


### PR DESCRIPTION
- exception.message was deprecated in python 2.6. just str(e)
  works now.

Signed-off-by: Joe Mills joe@midokura.com
Fixes MN-1429
