### PR TITLE
Re-enable the dependencies of the spec file

### DIFF
--- a/rhel/python-midonetclient.spec
+++ b/rhel/python-midonetclient.spec
@@ -18,9 +18,7 @@ BuildRoot:  /var/tmp/%{name}-buildroot
 # since rpm doesn't know about packages installed via dpkg. Leaving it
 # commented out until someone can test on an RPM system.
 # BuildRequires: python, python-support, python-unittest2, python-all-dev, ruby-ronn
-# Commented these out because they work in RHEL but CentOS still hasn't
-# got those packages available.
-# Requires: python >= 2.6, python-webob, python-eventlet, python-httplib2
+Requires: python >= 2.6, python-webob, python-eventlet, python-httplib2
 
 %description
 Python client for MidoNet REST API.


### PR DESCRIPTION
RHEL 6.5 and CentOS 6.5 can satify the required dependencies by adding
the OpenStack related RPM packages. So I'm assuming we can just
re-enable the commented "Requires" section in the spec file.

This resolves [MN1550](https://midobugs.atlassian.net/browse/MN-1550).

Signed-off-by: Taku Fukushima tfukushima@midokura.com
