### PR TITLE
Adds Vtep and VtepBinding to Python Client / CLI.

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -1863,6 +1863,12 @@ class BridgePort(ObjectType):
                                  setter = 'link',
                                  unsetter = 'unlink',
                                  optional = True))
+        self.put_attr(SingleAttr(name = 'management-ip',
+                                 value_type = IPv4Address(),
+                                 getter = 'get_mgmt_ip'))
+        self.put_attr(SingleAttr(name = 'vni',
+                                 value_type = StringType(),
+                                 getter = 'get_vni'))
 
 class PortBinding(ObjectType):
     def type_name(self):
@@ -2197,6 +2203,65 @@ class PoolStatistic(ObjectType):
         return 'ps'
 
 
+class Vtep(ObjectType):
+    def __init__(self, obj):
+        super(Vtep, self).__init__(obj)
+        self.clear_attrs()
+        self.put_attr(SingleAttr(name = 'name',
+                                 value_type = StringType(),
+                                 setter = '',
+                                 getter = 'get_name'))
+        # Description field is not implemented.
+        #self.put_attr(SingleAttr(name = 'description',
+        #                         value_type = StringType(),
+        #                         setter = 'description',
+        #                         getter = 'get_description'))
+        self.put_attr(SingleAttr(name = 'management-ip',
+                                 value_type = IPv4Address(),
+                                 getter = 'get_management_ip',
+                                 setter = 'management_ip'))
+        self.put_attr(SingleAttr(name = 'management-port',
+                                 value_type = L4PortNumber(),
+                                 getter = 'get_management_port',
+                                 setter = 'management_port'))
+        self.put_attr(SingleAttr(name = 'tunnel-zone-id',
+                                 value_type = UUID(),
+                                 getter = 'get_tunnel_zone_id',
+                                 setter = 'tunnel_zone_id'))
+        self.put_attr(Collection(name = 'binding',
+                                 element_type = VtepBinding,
+                                 list_method = '',
+                                 getter = '',
+                                 factory_method = 'add_binding'))
+
+    def type_name(self):
+        return "vtep"
+
+
+class VtepBinding(ObjectType):
+    def __init__(self, obj):
+        super(VtepBinding, self).__init__(obj)
+        self.clear_attrs()
+        self.put_attr(SingleAttr(name = 'management-ip',
+                                 value_type = IPv4Address(),
+                                 getter = 'get_management_ip'))
+        self.put_attr(SingleAttr(name = 'physical-port',
+                                 value_type = StringType(),
+                                 setter = 'port_name',
+                                 getter = 'get_port_name'))
+        self.put_attr(SingleAttr(name = 'vlan',
+                                 value_type = StringType(),
+                                 setter = 'vlan_id',
+                                 getter = 'get_vlan_id'))
+        self.put_attr(SingleAttr(name = 'network-id',
+                                 value_type = StringType(),
+                                 getter = 'get_network_id',
+                                 setter = 'network_id'))
+
+    def type_name(self):
+        return "binding"
+
+
 class Midonet(ObjectType):
     """ This is the root context for the CLI. At the beggining of matching on a
         command pattern the `MatchingContext` is initialized with an instance of
@@ -2275,6 +2340,11 @@ class Midonet(ObjectType):
                                  list_method = 'get_pool_statistics',
                                  getter = 'get_pool_statistic',
                                  factory_method = 'add_pool_statisic'))
+        self.put_attr(Collection(name = 'vtep',
+                                 element_type = Vtep,
+                                 list_method = 'get_vteps',
+                                 getter = '',
+                                 factory_method = 'add_vtep'))
 
 
 ################################################################################

--- a/src/midonetclient/api.py
+++ b/src/midonetclient/api.py
@@ -504,6 +504,18 @@ class MidonetApi(object):
         rule = rule.properties(vals.get("properties"))
         return rule.create()
 
+    def get_vteps(self):
+        self._ensure_application()
+        return self.app.get_vteps()
+
+    def add_vtep(self):
+        self._ensure_application()
+        return self.app.add_vtep()
+
+    def delete_vtep(self, mgmt_ip):
+        self._ensure_application()
+        return self.app.delete_vtep(mgmt_ip)
+
     def _ensure_application(self):
         if self.app is None:
             self.app = Application(None, {'uri': self.base_uri}, self.auth)

--- a/src/midonetclient/application.py
+++ b/src/midonetclient/application.py
@@ -43,12 +43,14 @@ from midonetclient.pool import Pool
 from midonetclient.pool_member import PoolMember
 from midonetclient.health_monitor import HealthMonitor
 from midonetclient.pool_statistic import PoolStatistic
+from midonetclient.vtep import Vtep
 
 
 class Application(ResourceBase):
 
     media_type = vendor_media_type.APPLICATION_JSON_V5
     ID_TOKEN = '{id}'
+    IP_ADDR_TOKEN = '{ipAddr}'
 
     def __init__(self, uri, dto, auth):
         super(Application, self).__init__(uri, dto, auth)
@@ -91,6 +93,9 @@ class Application(ResourceBase):
 
     def get_tunnel_zone_template(self):
         return self.dto['tunnelZoneTemplate']
+
+    def get_vtep_template(self):
+        return self.dto['vtepTemplate']
 
     def get_write_version_uri(self):
         return self.dto['writeVersion']
@@ -331,6 +336,12 @@ class Application(ResourceBase):
                                              id_)
         self.auth.do_request(uri, 'DELETE')
 
+    def _delete_resource_by_ip_addr(self, template, ip_address):
+        uri = self._create_uri_from_template(template,
+                                             self.IP_ADDR_TOKEN,
+                                             ip_address)
+        self.auth.do_request(uri, 'DELETE')
+
     #L4LB resources
     def get_load_balancers(self, query):
         headers = {'Accept':
@@ -437,3 +448,15 @@ class Application(ResourceBase):
 
     def add_pool_statistic(self):
         return PoolStatistic(self.dto['poolStatistics'], {}, self.auth)
+
+    def get_vteps(self):
+        headers = {'Accept':
+                   vendor_media_type.APPLICATION_VTEP_COLLECTION_JSON}
+        return self.get_children(self.dto['vteps'], {}, headers, Vtep)
+
+    def add_vtep(self):
+        return Vtep(self.dto['vteps'], {}, self.auth)
+
+    def delete_vtep(self, mgmt_ip):
+        return self._delete_resource_by_ip_addr(self.get_vtep_template(),
+                                                mgmt_ip)

--- a/src/midonetclient/bridge.py
+++ b/src/midonetclient/bridge.py
@@ -70,7 +70,24 @@ class Bridge(ResourceBase, AdminStateUpMixin):
             query = {}
         headers = {'Accept':
                    vendor_media_type.APPLICATION_PORT_V2_COLLECTION_JSON}
-        return self.get_children(self.dto['ports'], query, headers, Port)
+        ports = self.get_children(self.dto['ports'], query, headers, Port)
+
+        vxlan_port = self.get_vxlan_port()
+        if vxlan_port: ports.append(vxlan_port)
+
+        return ports
+
+    def get_vxlan_port(self):
+        """Returns a VxLan port.
+
+           Returns a VxLan port if one is configured, or None otherwise.
+        """
+        vxlan_port_dto = self.dto['vxLanPort']
+        if not vxlan_port_dto: return None 
+
+        vxlan_port = Port(vxlan_port_dto, {'uri': vxlan_port_dto}, self.auth)
+        vxlan_port.get({'Accept': vendor_media_type.APPLICATION_PORT_V2_JSON})
+        return vxlan_port
 
     def get_peer_ports(self, query=None):
         if query is None:

--- a/src/midonetclient/port.py
+++ b/src/midonetclient/port.py
@@ -19,13 +19,12 @@
 # @author: Ryu Ishimoto <ryu@midokura.com>, Midokura
 
 
-from midonetclient import port_type
 from midonetclient import resource_base
 from midonetclient import vendor_media_type
-from vendor_media_type import APPLICATION_PORTGROUP_PORT_COLLECTION_JSON
 from midonetclient import bgp
 from midonetclient import port_group_port
 from midonetclient.admin_state_up_mixin import AdminStateUpMixin
+from vendor_media_type import APPLICATION_PORTGROUP_PORT_COLLECTION_JSON
 
 
 class Port(resource_base.ResourceBase, AdminStateUpMixin):
@@ -82,6 +81,12 @@ class Port(resource_base.ResourceBase, AdminStateUpMixin):
         headers = {'Accept':
                    vendor_media_type.APPLICATION_BGP_COLLECTION_JSON}
         return self.get_children(self.dto['bgps'], query, headers, bgp.Bgp)
+
+    def get_mgmt_ip(self):
+        return self.dto['mgmtIpAddr']
+
+    def get_vni(self):
+        return self.dto['vni']
 
     def inbound_filter_id(self, id_):
         self.dto['inboundFilterId'] = id_

--- a/src/midonetclient/vendor_media_type.py
+++ b/src/midonetclient/vendor_media_type.py
@@ -157,3 +157,11 @@ APPLICATION_POOL_STATISTIC_JSON = \
     "application/vnd.org.midonet.PoolStatistic-v1+json"
 APPLICATION_POOL_STATISTIC_COLLECTION_JSON = \
     "application/vnd.org.midonet.collection.PoolStatistic-v1+json"
+
+# VxGW
+APPLICATION_VTEP_JSON = "application/vnd.org.midonet.VTEP-v1+json"
+APPLICATION_VTEP_COLLECTION_JSON = \
+            "application/vnd.org.midonet.collection.VTEP-v1+json"
+APPLICATION_VTEP_BINDING_JSON = "application/vnd.org.midonet.VTEPBinding-v1+json"
+APPLICATION_VTEP_BINDING_COLLECTION_JSON = \
+            "application/vnd.org.midonet.collection.VTEPBinding-v1+json"

--- a/src/midonetclient/vtep.py
+++ b/src/midonetclient/vtep.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2014 Midokura SARL, All Rights Reserved.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from midonetclient.resource_base import ResourceBase
+from midonetclient import vendor_media_type
+from midonetclient.vtep_binding import VtepBinding
+
+class Vtep(ResourceBase):
+
+    media_type = vendor_media_type.APPLICATION_VTEP_JSON
+
+    def __init__(self, uri, dto, auth):
+        super(Vtep, self).__init__(uri, dto, auth)
+
+    def get_name(self):
+        return self.dto['name']
+
+    def get_description(self):
+        return self.dto['description']
+
+    def get_management_ip(self):
+        return self.dto['managementIp']
+
+    def get_management_port(self):
+        return self.dto['managementPort']
+
+    def get_tunnel_ip_addresses(self):
+        return self.dto['tunnelIpAddrs']
+
+    def get_connection_state(self):
+        return self.dto['connectionState']
+
+    def get_tunnel_zone_id(self):
+        return self.dto['tunnelZoneId']
+
+    def name(self, name):
+        self.dto['name'] = name
+        return self
+
+    def description(self, desc):
+        self.dto['description'] = desc
+        return self
+
+    def management_ip(self, ip_addr):
+        self.dto['managementIp'] = ip_addr
+        return self
+
+    def management_port(self, port):
+        self.dto['managementPort'] = port
+        return self
+
+    def tunnel_ip_addresses(self, addresses):
+        self.dto['tunnelIpAddrs'] = addresses
+        return self
+
+    def connection_state(self, conn_state):
+        self.dto['connectionState'] = conn_state
+        return self
+
+    def tunnel_zone_id(self, tunnel_zone_id):
+        self.dto['tunnelZoneId'] = tunnel_zone_id
+        return self
+
+    def add_binding(self):
+        return VtepBinding(self.dto['bindings'],
+                           {'mgmtIp': self.get_management_ip()},
+                           self.auth)

--- a/src/midonetclient/vtep_binding.py
+++ b/src/midonetclient/vtep_binding.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2014 Midokura Europe SARL, All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from midonetclient.resource_base import ResourceBase
+from midonetclient import vendor_media_type
+
+class VtepBinding(ResourceBase):
+
+    media_type = vendor_media_type.APPLICATION_VTEP_BINDING_JSON
+
+    def __init__(self, uri, dto, auth):
+        super(VtepBinding, self).__init__(uri, dto, auth)
+
+    def get_management_ip(self):
+        return self.dto['mgmtIP']
+
+    def get_port_name(self):
+        return self.dto['portName']
+
+    def get_vlan_id(self):
+        return self.dto['vlanId']
+
+    def get_network_id(self):
+        return self.dto['networkId']
+
+    def port_name(self, port_name):
+        self.dto['portName'] = port_name
+        return self
+
+    def vlan_id(self, vlan_id):
+        self.dto['vlanId'] = vlan_id
+        return self
+
+    def network_id(self, network_id):
+        self.dto['networkId'] = network_id
+        return self
+
+    def create(self, headers=None):
+        """Does REST POST at some uri followed by REST GET at new location"""
+        headers = headers or dict()
+        self._ensure_content_type(headers)
+
+        self.auth.do_request(self.uri, 'POST', body=self.dto, headers=headers)
+        # TODO(tomohiko) This method override is a temporary workaround for
+        # unimplemented MidoNet API VTEP binding GET. Remove this once the GET
+        # is implemented.
+        return self


### PR DESCRIPTION
This implementation makes CLI handle a VxLan port as one of normal
ports.
- Adds Vtep and VtepBinding, wrapper classes for corresponding Midonet
  API DTOs.
- At the moment, all it can do is:
  1) to create a VTEP,
  2) list VTEPS,
  3) add a VTEP binding.
- Also implemented CLI.

Sample code fragment:

  # Create a new VTEP
  # vtep_management_ip/port are assumed to contain right values.
  vtep = mc.add_vtep().name('My VTEP').management_ip(vtep_management_ip).management_port(vtep_management_port).tunnel_zone_id(tunnel_zone_id').create()

  # Add a new VTEP binding.
  # bridge_id is assumed to contain a correct Mido bridge ID.
  vtep_binding = vtep.add_binding().port_name('in1').network_id(bridge_id).create()

Sample CLI inputs:

> midonet> create vtep management-ip 119.15.112.22 management-port 6633 tunnel-zone-id 7458850d-1bb3-4a0c-9cb9-2db37a178d04
> name br0 management-ip 119.15.112.22 management-port 6633
> midonet> vtep management-ip 119.15.112.22 add binding network-id 3eb8e295-a529-4e38-bd00-9380ed522e2d physical-port eth0 vlan 203
> physical-port eth0 vlan 203 network-id 3eb8e295-a529-4e38-bd00-9380ed522e2d
> midonet> bridge bridge0 list port
> port port0 device bridge0 state up
> port port1 device bridge0 state up vlan -1 management-ip 119.15.112.22 vni 6692687

Not implemented yet:
- Allowing the specification of management address as IP-ADDR:PORT.
  Eg. "management-address 119.15.112.22:6633"
- Allowing a tunnel-zone-reference for VTEP creation.
- Similarly allowing a bridge reference for network ID?

Fix MN-1586
