### PR TITLE
CLI can show VTEP configurations.

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -2228,9 +2228,13 @@ class Vtep(ObjectType):
                                  value_type = UUID(),
                                  getter = 'get_tunnel_zone_id',
                                  setter = 'tunnel_zone_id'))
+        self.put_attr(SingleAttr(name = 'connection-state',
+                                 value_type = StringType(),
+                                 getter = 'get_connection_state',
+                                 setter = ''))
         self.put_attr(Collection(name = 'binding',
                                  element_type = VtepBinding,
-                                 list_method = '',
+                                 list_method = 'get_bindings',
                                  getter = '',
                                  factory_method = 'add_binding'))
 
@@ -2244,7 +2248,7 @@ class VtepBinding(ObjectType):
         self.clear_attrs()
         self.put_attr(SingleAttr(name = 'management-ip',
                                  value_type = IPv4Address(),
-                                 getter = 'get_management_ip'))
+                                 getter = 'get_mgmt_ip'))
         self.put_attr(SingleAttr(name = 'physical-port',
                                  value_type = StringType(),
                                  setter = 'port_name',
@@ -2343,7 +2347,7 @@ class Midonet(ObjectType):
         self.put_attr(Collection(name = 'vtep',
                                  element_type = Vtep,
                                  list_method = 'get_vteps',
-                                 getter = '',
+                                 getter = 'get_vtep',
                                  factory_method = 'add_vtep'))
 
 

--- a/src/midonetclient/api.py
+++ b/src/midonetclient/api.py
@@ -512,6 +512,10 @@ class MidonetApi(object):
         self._ensure_application()
         return self.app.add_vtep()
 
+    def get_vtep(self, mgmt_ip):
+        self._ensure_application()
+        return self.app.get_vtep(mgmt_ip)
+
     def delete_vtep(self, mgmt_ip):
         self._ensure_application()
         return self.app.delete_vtep(mgmt_ip)

--- a/src/midonetclient/application.py
+++ b/src/midonetclient/application.py
@@ -330,6 +330,13 @@ class Application(ResourceBase):
                                              id_)
         return self._get_resource(clazz, create_uri, uri)
 
+    def _get_resource_by_ip_addr(self, clazz, create_uri,
+                                 template, ip_address):
+        uri = self._create_uri_from_template(template,
+                                             self.IP_ADDR_TOKEN,
+                                             ip_address)
+        return self._get_resource(clazz, create_uri, uri)
+
     def _delete_resource_by_id(self, template, id_):
         uri = self._create_uri_from_template(template,
                                              self.ID_TOKEN,
@@ -456,6 +463,12 @@ class Application(ResourceBase):
 
     def add_vtep(self):
         return Vtep(self.dto['vteps'], {}, self.auth)
+
+    def get_vtep(self, mgmt_ip):
+        return self._get_resource_by_ip_addr(Vtep,
+                                             self.dto['vteps'],
+                                             self.get_vtep_template(),
+                                             mgmt_ip)
 
     def delete_vtep(self, mgmt_ip):
         return self._delete_resource_by_ip_addr(self.get_vtep_template(),

--- a/src/midonetclient/vtep.py
+++ b/src/midonetclient/vtep.py
@@ -73,6 +73,15 @@ class Vtep(ResourceBase):
         self.dto['tunnelZoneId'] = tunnel_zone_id
         return self
 
+    def get_bindings(self):
+        query = {}
+        headers = {'Accept':
+                   vendor_media_type.APPLICATION_VTEP_BINDING_COLLECTION_JSON}
+        return self.get_children(self.dto['bindings'],
+                                 query,
+                                 headers,
+                                 VtepBinding)
+
     def add_binding(self):
         return VtepBinding(self.dto['bindings'],
                            {'mgmtIp': self.get_management_ip()},

--- a/src/midonetclient/vtep_binding.py
+++ b/src/midonetclient/vtep_binding.py
@@ -22,8 +22,8 @@ class VtepBinding(ResourceBase):
     def __init__(self, uri, dto, auth):
         super(VtepBinding, self).__init__(uri, dto, auth)
 
-    def get_management_ip(self):
-        return self.dto['mgmtIP']
+    def get_mgmt_ip(self):
+        return self.dto['mgmtIp']
 
     def get_port_name(self):
         return self.dto['portName']
@@ -33,6 +33,10 @@ class VtepBinding(ResourceBase):
 
     def get_network_id(self):
         return self.dto['networkId']
+
+    def mgmt_ip(self, management_ip):
+        self.dto['mgmtIP'] = management_ip
+        return self
 
     def port_name(self, port_name):
         self.dto['portName'] = port_name


### PR DESCRIPTION
- Can display full configuration info such as connection state.
- Can list all the bindings for a VTEP.

Sample CLI command lines:

midonet> vtep list
name br0 management-ip 119.15.112.22 management-port 6633 connection-state CONNECTED
midonet> vtep management-ip 119.15.112.22 list binding
management-ip 100.100.100.1 physical-port eth0 vlan 201 network-id ca07e054-2cef-4b6e-8d0a-c3b8e747615b
management-ip 100.100.100.2 physical-port eth0 vlan 202 network-id 60e94be7-276b-4eec-a845-f16671f01467

Fix MN-1638
