### PR TITLE
Add Port MacAddress to Port.

### DIFF
--- a/src/midonetclient/port.py
+++ b/src/midonetclient/port.py
@@ -116,6 +116,10 @@ class Port(resource_base.ResourceBase, AdminStateUpMixin):
         self.dto['networkLength'] = network_length
         return self
 
+    def mac_address(self, portMac):
+        self.dto['portMac'] = portMac
+        return self
+
     def type(self, type_):
         self.dto['type'] = type_
         return self


### PR DESCRIPTION
I'd like to add a Port MacAdress to port.py. Our customer want to create a router port with specific mac address on provider router. This is my idea.

provider_router.add_port().port_address('2.2.2.2').network_address('2.2.2.0').network_length(24).mac_address('00:1B:21:D8:EF:FF').create()

Signed-off-by: Takaaki Suzuki captain@midokura.com
