### PR TITLE
Fix the typo in the persistence attribute of VIP class

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -2039,7 +2039,7 @@ class VIP(ObjectType):
                                  getter = 'get_protocol_port',
                                  setter = 'protocol_port'))
         self.put_attr(EnumAttr(name = 'persistence',
-                               mappings = {'SOURCE_IP': 'SOURCE_IP', 'NONE', None},
+                               mappings = {'SOURCE_IP': 'SOURCE_IP', 'NONE': None},
                                getter = 'get_session_persistence',
                                setter = 'session_persistence',
                                optional = True))


### PR DESCRIPTION
This patch fixes the typo introduced by d2682f1fae.

Signed-off-by: Taku Fukushima tfukushima@midokura.com
