### PR TITLE
Add port_mac method to Port

### DIFF
--- a/src/midonetclient/port.py
+++ b/src/midonetclient/port.py
@@ -111,6 +111,10 @@ class Port(resource_base.ResourceBase, AdminStateUpMixin):
         self.dto['networkLength'] = network_length
         return self
 
+    def port_mac(self, port_mac):
+        self.dto['portMac'] = port_mac
+        return self
+
     def type(self, type_):
         self.dto['type'] = type_
         return self


### PR DESCRIPTION
This patch adds the missing port_mac setter method to Port class.

This fixes MN-1911.

Signed-off-by: Takaaki Suzuki captain@midokura.com
Signed-off-by: Taku Fukushima tfukushima@midokura.com
