### PR TITLE
Replace mac_address with port_mac in Port class

### DIFF
--- a/src/midonetclient/port.py
+++ b/src/midonetclient/port.py
@@ -116,8 +116,8 @@ class Port(resource_base.ResourceBase, AdminStateUpMixin):
         self.dto['networkLength'] = network_length
         return self
 
-    def mac_address(self, portMac):
-        self.dto['portMac'] = portMac
+    def port_mac(self, port_mac):
+        self.dto['portMac'] = port_mac
         return self
 
     def type(self, type_):


### PR DESCRIPTION
This patch fixes the inconsistent attribute name which is different from
the name specified in midonet-cli file introduced by d49a7ea2967.

This fixes MN-1911.

Signed-off-by: Taku Fukushima tfukushima@midokura.com
