### PR TITLE
VTEP binding deletion CLI

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -27,6 +27,7 @@ from shlex import split as shsplit
 from webob import exc
 
 from midonetclient.api import MidonetApi
+from midonetclient.resource_base import ResourceId
 
 ################################################################################
 # Utility functions
@@ -34,11 +35,38 @@ from midonetclient.api import MidonetApi
 
 uuid_pattern = re.compile("^[0-F]{8}-[0-F]{4}-[0-F]{4}-[0-F]{4}-[0-F]{12}$", re.I)
 def is_valid_uuid(value):
-    return True if uuid_pattern.match(value) is not None else False
+    return uuid_pattern.match(str(value))
+
 
 hex_uuid_pattern = re.compile("^[0-F]{32}$", re.I)
 def is_valid_hex_uuid(value):
-    return True if hex_uuid_pattern.match(value) is not None else False
+    return hex_uuid_pattern.match(str(value))
+
+
+def is_resource_id(value):
+    """Tests if it's a ResourceID."""
+    return isinstance(value, ResourceId)
+
+
+def is_inverted_name_str(value):
+    """Tests if it's an inverted (prefixed with "!") UUID/alias string."""
+    return str(value).startswith("!")
+
+
+def normalize_inverted_name_str(name):
+    """Returns the original (without "!") UUID/alias string.
+
+    Args:
+        name: An inverted UUID/alias string.
+    Returns:
+        The UUID/alias string without "!" prefix.
+    """
+    return name.lstrip('!')
+
+
+def invert_name_str(name):
+    """Inverts the name string."""
+    return "!%s" % name
 
 ################################################################################
 # Session initialization
@@ -373,7 +401,7 @@ class SingleAttr(Attr):
             if self.has_inv():
                 func = obj.reflect(self.inv_getter)
                 if func():
-                    return "!%s" % (v)
+                    return invert_name_str(v)
         except KeyError as e:
             pass
         return v
@@ -399,9 +427,9 @@ class SingleAttr(Attr):
         v = value
         if self.inv_setter is not None:
             inv = False
-            if (value.startswith("!")):
+            if is_inverted_name_str(value):
                 inv = True
-                v = value.lstrip('!')
+                v = normalize_inverted_name_str(value)
             func = obj.reflect(self.inv_setter)
             func(inv)
         return v
@@ -887,22 +915,24 @@ class Namespace():
         return "%s%s" % (prefix, count)
 
     def lookup(self, name):
-        """Looks up a corresponding UUID for a given alias.
+        """Resolves an alias to a corresponding UUID if one is given.
 
         Arguments:
-        name -- An alias. Might be in the inverted form. Eg. "!pgroup0"
+            name: An alias, a UUID string, or a ResourceId instance. Might be in
+                  the inverted form. E.g. "!pgroup0"
 
-        Returns: An UUID for the alias. If the alias is inverted, its UUID would
-        also be inverted as in "!d3ab9c45-1e83-4c44-864f-51e698d6cc47".
+        Returns:
+            An UUID for the alias. If the alias is inverted, its UUID would also
+            be inverted as in "!d3ab9c45-1e83-4c44-864f-51e698d6cc47".
         """
         normalized_name = name
         is_inverse = False
-        if name.startswith("!"):
-            normalized_name = name.lstrip('!')
+        if is_inverted_name_str(name):
+            normalized_name = normalize_inverted_name_str(name)
             is_inverse = True
         if self._aliases.has_key(normalized_name):
             resolved = self._aliases[normalized_name]
-            if is_inverse: resolved = '!%s' % resolved
+            if is_inverse: resolved = invert_name_str(resolved)
             return resolved
         else:
             return None
@@ -951,7 +981,10 @@ class AliasManager():
     # definition) to each component in the chain of aliases. So aliases need to
     # store both uuid and attribute spec.
     def lookup(self, name, parent=None):
-        chain = name.split(':')
+        if is_resource_id(name):
+            chain = [name]
+        else:
+            chain = name.split(':')
         namespace = self._root_namespace
         resolved = None
 
@@ -1151,7 +1184,18 @@ class ObjectType(object):
         return False
 
     def fetch_one_for_type(self, object_type, id_):
-        if not is_valid_uuid(id_):
+        """Fetches one object with specified type & ID.
+
+        Args:
+            object_type: String indicating the type. E.g. bridge
+            id_: An ID of the object. This could be either:
+                 1. A UUID string,
+                 2. A ResourceId instance.
+
+        Returns:
+            The fetched object, or None if one doesn't exist.
+        """
+        if not (is_resource_id(id_) or is_valid_uuid(id_)):
             return None
 
         if not self.has_type(object_type):
@@ -1161,7 +1205,17 @@ class ObjectType(object):
         if not attr.getter:
             return None
 
-        func = app.reflect(attr.getter)
+        # We should look up a corresponding getter in the current context,
+        # e.g. VtepBinding for vtep0:binding:0. However, the pre-existing
+        # implementation always looks up in the top level "app" (=Midonet),
+        # which I believe is a bug. Need to keep the behavior for now otherwise
+        # it breaks for chain:rule, for example.
+        # TODO(tomohiko) Fix this.
+        try:
+            func = self.reflect(attr.getter)
+        except:
+            func = app.reflect(attr.getter)
+
         try:
             obj = func(id_)
         except:
@@ -2208,15 +2262,15 @@ class Vtep(ObjectType):
     def __init__(self, obj):
         super(Vtep, self).__init__(obj)
         self.clear_attrs()
+        self.put_attr(SingleAttr(name = 'id',
+                                 value_type = StringType(),
+                                 getter = 'get_id',
+                                 writeable = False,
+                                 show = False))
         self.put_attr(SingleAttr(name = 'name',
                                  value_type = StringType(),
                                  setter = '',
                                  getter = 'get_name'))
-        # Description field is not implemented.
-        #self.put_attr(SingleAttr(name = 'description',
-        #                         value_type = StringType(),
-        #                         setter = 'description',
-        #                         getter = 'get_description'))
         self.put_attr(SingleAttr(name = 'management-ip',
                                  value_type = IPv4Address(),
                                  getter = 'get_management_ip',
@@ -2236,7 +2290,7 @@ class Vtep(ObjectType):
         self.put_attr(Collection(name = 'binding',
                                  element_type = VtepBinding,
                                  list_method = 'get_bindings',
-                                 getter = '',
+                                 getter = 'get_binding',
                                  factory_method = 'add_binding'))
 
     def type_name(self):
@@ -2247,6 +2301,11 @@ class VtepBinding(ObjectType):
     def __init__(self, obj):
         super(VtepBinding, self).__init__(obj)
         self.clear_attrs()
+        self.put_attr(SingleAttr(name = 'id',
+                                 value_type = StringType(),
+                                 getter = 'get_id',
+                                 writeable = False,
+                                 show = False))
         self.put_attr(SingleAttr(name = 'management-ip',
                                  value_type = IPv4Address(),
                                  getter = 'get_mgmt_ip'))
@@ -2348,7 +2407,8 @@ class Midonet(ObjectType):
         self.put_attr(Collection(name = 'vtep',
                                  element_type = Vtep,
                                  list_method = 'get_vteps',
-                                 getter = 'get_vtep',
+                                 getter = 'get_vtep_by_id',
+                                 list_with_tenant = True,
                                  factory_method = 'add_vtep'))
 
 

--- a/src/midonetclient/api.py
+++ b/src/midonetclient/api.py
@@ -504,17 +504,35 @@ class MidonetApi(object):
         rule = rule.properties(vals.get("properties"))
         return rule.create()
 
-    def get_vteps(self):
+    def get_vteps(self, query):
         self._ensure_application()
-        return self.app.get_vteps()
+        return self.app.get_vteps(query)
 
     def add_vtep(self):
         self._ensure_application()
         return self.app.add_vtep()
 
     def get_vtep(self, mgmt_ip):
+        """Looks up a VTEP resource for the specified management IP address.
+
+        Args:
+            mgmt_ip: A management IP address.
+        Returns:
+            A VTEP resource.
+        """
         self._ensure_application()
         return self.app.get_vtep(mgmt_ip)
+
+    def get_vtep_by_id(self, vtep_id):
+        """Looks up a VTEP resource for the specified VtepId.
+
+        Args:
+            vtep_id: A VtepId.
+        Returns:
+            A VTEP resource.
+        """
+        self._ensure_application()
+        return self.app.get_vtep_by_id(vtep_id)
 
     def delete_vtep(self, mgmt_ip):
         self._ensure_application()

--- a/src/midonetclient/application.py
+++ b/src/midonetclient/application.py
@@ -49,8 +49,6 @@ from midonetclient.vtep import Vtep
 class Application(ResourceBase):
 
     media_type = vendor_media_type.APPLICATION_JSON_V5
-    ID_TOKEN = '{id}'
-    IP_ADDR_TOKEN = '{ipAddr}'
 
     def __init__(self, uri, dto, auth):
         super(Application, self).__init__(uri, dto, auth)
@@ -315,40 +313,6 @@ class Application(ResourceBase):
         return self.get_children(self.dto['hostVersions'],
                                  query, headers, HostVersion)
 
-    def _create_uri_from_template(self, template, token, value):
-        return template.replace(token, value)
-
-    def _get_resource(self, clazz, create_uri, uri):
-        return clazz(create_uri, {'uri': uri}, self.auth).get(
-            headers={'Content-Type': clazz.media_type,
-                     'Accept': clazz.media_type})
-
-    def _get_resource_by_id(self, clazz, create_uri,
-                            template, id_):
-        uri = self._create_uri_from_template(template,
-                                             self.ID_TOKEN,
-                                             id_)
-        return self._get_resource(clazz, create_uri, uri)
-
-    def _get_resource_by_ip_addr(self, clazz, create_uri,
-                                 template, ip_address):
-        uri = self._create_uri_from_template(template,
-                                             self.IP_ADDR_TOKEN,
-                                             ip_address)
-        return self._get_resource(clazz, create_uri, uri)
-
-    def _delete_resource_by_id(self, template, id_):
-        uri = self._create_uri_from_template(template,
-                                             self.ID_TOKEN,
-                                             id_)
-        self.auth.do_request(uri, 'DELETE')
-
-    def _delete_resource_by_ip_addr(self, template, ip_address):
-        uri = self._create_uri_from_template(template,
-                                             self.IP_ADDR_TOKEN,
-                                             ip_address)
-        self.auth.do_request(uri, 'DELETE')
-
     #L4LB resources
     def get_load_balancers(self, query):
         headers = {'Accept':
@@ -456,19 +420,39 @@ class Application(ResourceBase):
     def add_pool_statistic(self):
         return PoolStatistic(self.dto['poolStatistics'], {}, self.auth)
 
-    def get_vteps(self):
+    def get_vteps(self, query):
         headers = {'Accept':
                    vendor_media_type.APPLICATION_VTEP_COLLECTION_JSON}
-        return self.get_children(self.dto['vteps'], {}, headers, Vtep)
+        return self.get_children(self.dto['vteps'], query, headers, Vtep)
 
     def add_vtep(self):
         return Vtep(self.dto['vteps'], {}, self.auth)
 
     def get_vtep(self, mgmt_ip):
+        """Looks up a VTEP resource for the specified management IP address.
+
+        Args:
+            mgmt_ip: A management IP address.
+        Returns:
+            A VTEP resource.
+        """
         return self._get_resource_by_ip_addr(Vtep,
                                              self.dto['vteps'],
                                              self.get_vtep_template(),
                                              mgmt_ip)
+
+    def get_vtep_by_id(self, vtep_id):
+        """Looks up a VTEP resource for the specified VtepId.
+
+        Args:
+            vtep_id: A VtepId.
+        Returns:
+            A VTEP resource.
+        """
+        return self._get_resource_by_ip_addr(Vtep,
+                                             self.dto['vteps'],
+                                             self.get_vtep_template(),
+                                             vtep_id.management_ip)
 
     def delete_vtep(self, mgmt_ip):
         return self._delete_resource_by_ip_addr(self.get_vtep_template(),

--- a/src/midonetclient/util.py
+++ b/src/midonetclient/util.py
@@ -1,0 +1,25 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2014 Midokura SARL, All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import re
+
+
+ipv4_pattern = re.compile(
+        "[12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2}$",
+        re.I)
+
+def is_valid_ipv4_address(string):
+    return ipv4_pattern.match(str(string))

--- a/src/midonetclient/vtep.py
+++ b/src/midonetclient/vtep.py
@@ -13,13 +13,17 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from midonetclient.resource_base import ResourceBase
 from midonetclient import vendor_media_type
+from midonetclient.resource_base import ResourceBase
+from midonetclient.resource_base import ResourceId
+from midonetclient.util import is_valid_ipv4_address
 from midonetclient.vtep_binding import VtepBinding
 
 class Vtep(ResourceBase):
 
     media_type = vendor_media_type.APPLICATION_VTEP_JSON
+    PORT_NAME = '{portName}'
+    VLAN_ID = '{vlanId}'
 
     def __init__(self, uri, dto, auth):
         super(Vtep, self).__init__(uri, dto, auth)
@@ -44,6 +48,10 @@ class Vtep(ResourceBase):
 
     def get_tunnel_zone_id(self):
         return self.dto['tunnelZoneId']
+
+    def get_id(self):
+        """Returns a VtepId for this VTEP."""
+        return VtepId(self.get_management_ip())
 
     def name(self, name):
         self.dto['name'] = name
@@ -73,6 +81,9 @@ class Vtep(ResourceBase):
         self.dto['tunnelZoneId'] = tunnel_zone_id
         return self
 
+    def get_vtep_binding_template(self):
+        return self.dto['vtepBindingTemplate']
+
     def get_bindings(self):
         query = {}
         headers = {'Accept':
@@ -86,3 +97,36 @@ class Vtep(ResourceBase):
         return VtepBinding(self.dto['bindings'],
                            {'mgmtIp': self.get_management_ip()},
                            self.auth)
+
+    def get_binding(self, binding_id):
+        """Returns a binding for this VTEP with the given VtepBindingId.
+
+        Args:
+            binding_id: A VtepBindingId.
+        Returns:
+            A binding for this VTEP with the given VtepBindingId.
+        """
+        return self._get_resource_with_params(
+                VtepBinding, self.get_uri(), self.get_vtep_binding_template(),
+                {self.PORT_NAME : binding_id.port_name,
+                 self.VLAN_ID : binding_id.vlan_id})
+
+
+class VtepId(ResourceId):
+    """Represents a VTEP ID, which is its management IP address."""
+    def __init__(self, ip_addr):
+        super(ResourceId, self).__init__()
+
+        if not is_valid_ipv4_address(ip_addr):
+            raise Exception("Invalid IPv4 address passed to VtepId.")
+        self.management_ip = ip_addr
+
+    def __str__(self):
+        return 'VTEP-MANAGEMENT-IP:%s' % self.management_ip
+
+    def __eq__(self, other):
+        return (isinstance(other, VtepId) and
+                self.management_ip == other.management_ip)
+
+    def __hash__(self):
+        return self.management_ip.__hash__()

--- a/src/midonetclient/vtep_binding.py
+++ b/src/midonetclient/vtep_binding.py
@@ -11,9 +11,10 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
-from midonetclient.resource_base import ResourceBase
 from midonetclient import vendor_media_type
+from midonetclient.resource_base import ResourceBase
+from midonetclient.resource_base import ResourceId
+from midonetclient.util import is_valid_ipv4_address
 
 class VtepBinding(ResourceBase):
 
@@ -21,6 +22,16 @@ class VtepBinding(ResourceBase):
 
     def __init__(self, uri, dto, auth):
         super(VtepBinding, self).__init__(uri, dto, auth)
+
+    def get_id(self):
+        """Returns a VtepBindingId for this binding.
+
+        The ID of a VTEP binding is a composite key of its management IP,
+        physical port, and VLAN ID.
+        """
+        return VtepBindingId(self.get_mgmt_ip(),
+                             self.get_port_name(),
+                             self.get_vlan_id())
 
     def get_mgmt_ip(self):
         return self.dto['mgmtIp']
@@ -49,3 +60,30 @@ class VtepBinding(ResourceBase):
     def network_id(self, network_id):
         self.dto['networkId'] = network_id
         return self
+
+
+class VtepBindingId(ResourceId):
+    """Represents a VTEP binding composite ID."""
+    def __init__(self, management_ip, port_name, vlan_id):
+        super(ResourceId, self).__init__()
+
+        if not is_valid_ipv4_address(management_ip):
+            raise Exception("Invalid IPv4 address passed to VtepBindingId.")
+        self.management_ip = management_ip
+        self.port_name = port_name
+        self.vlan_id = vlan_id
+
+    def __str__(self):
+        return ('VTEPBinding:VTEP-MANAGEMENT-IP=%s,'
+                'PORT-NAME=%s,VLAN=%s' % (self.management_ip,
+                                          self.port_name,
+                                          str(self.vlan_id)))
+
+    def __eq__(self, other):
+        return (isinstance(other, VtepBindingId) and
+                self.management_ip == other.management_ip and
+                self.port_name == other.port_name and
+                self.vlan_id == other.vlan_id)
+
+    def __hash__(self):
+        return str(self).__hash__()


### PR DESCRIPTION
Makes VTEP and VTEP bindings aliased, and allows referencing them via
aliases for show / list / delete commands.

Sample command lines:
midonet> list vtep
vtep vtep0 name br0 management-ip 119.15.112.22 management-port 6633 connection-state CONNECTED
midonet> vtep vtep0 show management-ip
119.15.112.22
midonet> vtep vtep0 list binding
binding binding0 management-ip 119.15.112.22 physical-port Te 0/2 vlan 908 network-id bc3afc36-6274-4603-9109-c29f1c12ba33
binding binding1 management-ip 119.15.112.22 physical-port Te 0/2 vlan 439 network-id bc3afc36-6274-4603-9109-c29f1c12ba33
binding binding2 management-ip 119.15.112.22 physical-port Te 0/2 vlan 777 network-id bc3afc36-6274-4603-9109-c29f1c12ba33
binding binding3 management-ip 119.15.112.22 physical-port fakevm1_out vlan 0 network-id 7071b156-5f05-4d8c-8df2-3bb22a9325fc
binding binding4 management-ip 119.15.112.22 physical-port in1 vlan 119 network-id 1d475afc-d892-4dc7-af72-9bd88e565dde
midonet> vtep vtep0 binding binding4 show vlan
119
midonet> vtep vtep0 binding binding4 delete
midonet>

Fix MN-1824
