### PR TITLE
MidoNet CLI support for license management

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -846,6 +846,8 @@ class Collection(Attr):
                  getter = None,
                  sort_by = None,
                  factory_method = None,
+                 install_method = None,
+                 status_method = None,
                  show = True):
         self.name = name
         self.element_type = element_type
@@ -853,6 +855,8 @@ class Collection(Attr):
         self.getter = getter
         self.list_with_tenant = list_with_tenant
         self.factory_method = factory_method
+        self.install_method = install_method
+        self.status_method = status_method
         self.show = show
         self.sort_by = sort_by
 
@@ -2266,6 +2270,54 @@ class VtepBinding(ObjectType):
     def type_name(self):
         return "binding"
 
+class License(ObjectType):
+    def __init__(self, obj):
+        super(License, self).__init__(obj)
+        self.clear_attrs()
+        self.put_attr(SingleAttr(name = 'id',
+                                 value_type= UUID(),
+                                 getter = 'get_id'))
+        self.put_attr(SingleAttr(name = 'issuer',
+                                 value_type=StringType(),
+                                 getter = 'get_issuer'))
+        self.put_attr(SingleAttr(name = 'holder',
+                                 value_type=StringType(),
+                                 getter = 'get_holder'))
+        self.put_attr(SingleAttr(name = 'start_date',
+                                 value_type=StringType(),
+                                 getter = 'get_start_date'))
+        self.put_attr(SingleAttr(name = 'end_date',
+                                 value_type=StringType(),
+                                 getter = 'get_end_date'))
+        self.put_attr(SingleAttr(name = 'product',
+                                 value_type=StringType(),
+                                 getter = 'get_product'))
+        self.put_attr(SingleAttr(name = 'description',
+                                 value_type=StringType(),
+                                 getter = 'get_description'))
+        self.put_attr(SingleAttr(name = 'agent_quota',
+                                 value_type=ValueType(),
+                                 getter = 'get_agent_quota'))
+        self.put_attr(SingleAttr(name = 'valid',
+                                 value_type=BooleanType(),
+                                 getter = 'is_valid'))
+
+    def type_name(self):
+        return "license"
+
+class LicenseStatus(ObjectType):
+    def __init__(self, obj):
+        super(LicenseStatus, self).__init__(obj)
+        self.clear_attrs()
+        self.put_attr(SingleAttr(name = 'valid',
+                                 value_type = BooleanType(),
+                                 getter = 'is_valid'))
+        self.put_attr(SingleAttr(name = 'message',
+                                 value_type = StringType(),
+                                 getter = 'get_message'))
+
+    def type_name(self):
+        return "LicenseStatus"
 
 def _port_resolver(port):
     # This function dispatches the appropriate port class depending on the
@@ -2367,6 +2419,15 @@ class Midonet(ObjectType):
                                  list_method = 'get_vteps',
                                  getter = 'get_vtep',
                                  factory_method = 'add_vtep'))
+        self.put_attr(Collection(name = 'license',
+                                 element_type = License,
+                                 list_method = 'get_licenses',
+                                 getter = 'get_license',
+                                 install_method = 'install_license',
+                                 status_method= 'status_license'))
+        self.put_attr(Collection(name = 'license_status',
+                                 element_type = LicenseStatus,
+                                 list_method = None))
 
 
 ################################################################################
@@ -3717,6 +3778,125 @@ class List(Command):
             else:
                 print o.describe()
 
+class Install(Command):
+    """install - Installs an existing object from file
+
+    Usage: install <TYPE> <FILE>
+           <TYPE> install <FILE>
+
+    Examples:
+           install license <file-name>
+           license install <file-name>
+    """
+
+    def patterns(self):
+        install = Verb('install', partial_match = False, set_command = self)
+        col_type = CollectionByType()
+
+        patterns = install + col_type + SingleValue(StringType())
+        patterns |= col_type + install + SingleValue(StringType())
+        return patterns
+
+    def help(self):
+        print self.__doc__
+
+    def name(self):
+        return 'install'
+
+    def do(self, tokens):
+        assert(len(tokens) == 3)
+        collection = None
+        file = None
+        for tok in tokens:
+            if isinstance(tok, Collection):
+                 collection = tok
+            elif isinstance(tok, SingleValue):
+                file = tok
+        assert(collection is not None and file is not None)
+
+        if collection is None:
+            raise Exception("Bug in command pattern definition")
+
+        if not collection.install_method:
+            raise Exception("Installing elements of this type is not possible")
+
+        object_chain = []
+
+        attr = app.attrs()['license']
+        install = app.reflect(collection.install_method)
+        obj = install(file)
+        ref = attr.element_type(obj)
+
+        if isinstance(ref, ObjectType):
+            object_chain.append(ref)
+
+        alias_chain = aliases.add(*object_chain)
+
+        if alias_chain:
+            alias = alias_chain.pop()
+            print "%s %s %s" % (ref.type_name(), alias, ref.describe())
+        else:
+            print "%s %s" % (ref.type_name(), ref.describe())
+
+class Status(Command):
+    """status - Shows the status of the specified object
+
+    Usage: status <TYPE>
+           <TYPE> status
+
+    Example:
+           status license
+           license status
+    """
+
+    def patterns(self):
+        status = Verb('status', partial_match = False, set_command = self)
+        col_type = CollectionByType()
+
+        patterns = status + col_type
+        patterns |= col_type + status
+        return patterns
+
+    def help(self):
+        print self.__doc__
+
+    def name(self):
+        return 'status'
+
+    def do(self, tokens):
+        assert(len(tokens) == 2)
+        collection = None
+        for tok in tokens:
+            if isinstance(tok, Collection):
+                collection = tok
+        assert(collection is not None)
+
+        if collection is None:
+            raise Exception("Bug in command pattern definition.")
+
+        if not collection.status_method:
+            raise Exception("Checking the status for elements of this type is"
+                            "not possible");
+
+        object_chain = []
+
+        attr = app.attrs()['license_status']
+        status = app.reflect(collection.status_method)
+        obj = status()
+        ref = attr.element_type(obj)
+
+        if isinstance(ref, ObjectType):
+            object_chain.append(ref)
+
+        alias_chain = aliases.add(*object_chain)
+
+        if alias_chain:
+            alias = alias_chain.pop()
+            print "%s %s %s" % (ref.type_name(), alias, ref.describe())
+        else:
+            print "%s %s" % (ref.type_name(), ref.describe())
+
+
 ################################################################################
 # Autocomplete cache
 ################################################################################
@@ -3771,7 +3951,8 @@ class MidonetCLI(cmd.Cmd):
         cmd.Cmd.__init__(self)
         self._root = root
         self._ops = [Show(), List(), Create(), Delete(), Set(), Clear(),
-                     Describe(), Debug(), PushTenant(), PopTenant()]
+                     Describe(), Debug(), PushTenant(), PopTenant(), Install(),
+                     Status()]
         for op in self._ops:
             if op.name() is not None:
                 setattr(self, "help_%s" % op.name(), op.help)

--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -847,7 +847,6 @@ class Collection(Attr):
                  sort_by = None,
                  factory_method = None,
                  install_method = None,
-                 status_method = None,
                  show = True):
         self.name = name
         self.element_type = element_type
@@ -856,7 +855,6 @@ class Collection(Attr):
         self.list_with_tenant = list_with_tenant
         self.factory_method = factory_method
         self.install_method = install_method
-        self.status_method = status_method
         self.show = show
         self.sort_by = sort_by
 
@@ -2317,7 +2315,7 @@ class LicenseStatus(ObjectType):
                                  getter = 'get_message'))
 
     def type_name(self):
-        return "LicenseStatus"
+        return "license_status"
 
 def _port_resolver(port):
     # This function dispatches the appropriate port class depending on the
@@ -2423,11 +2421,11 @@ class Midonet(ObjectType):
                                  element_type = License,
                                  list_method = 'get_licenses',
                                  getter = 'get_license',
-                                 install_method = 'install_license',
-                                 status_method= 'status_license'))
+                                 install_method = 'install_license'))
         self.put_attr(Collection(name = 'license_status',
                                  element_type = LicenseStatus,
-                                 list_method = None))
+                                 list_method = None,
+                                 getter = 'get_license_status'))
 
 
 ################################################################################
@@ -3584,7 +3582,8 @@ class Delete(Command):
 class Show(Command):
     """show - Show an object or field
 
-    Usage: s[how] <OBJECT> {<CHILD>} [<FIELD>]
+    Usage: s[how] <TYPE>
+           s[how] <OBJECT> {<CHILD>} [<FIELD>]
            <OBJECT> s[how] {<CHILD>} [<FIELD>]
            <OBJECT> {<CHILD>} s[how] [<FIELD>]
            <OBJECT> {<CHILD>} [<FIELD>] s[how]
@@ -3601,9 +3600,11 @@ class Show(Command):
         obj = ObjectById()
         single_obj = SingleObjectByName()("+") | RootCtxToken()
         obj_in_col = ObjectFromCollection()
+        col_type = CollectionByType()
         field = FieldByName()
 
-        patterns = show + single_obj + field
+        patterns = show + col_type
+        patterns |= show + single_obj + field
         patterns |= single_obj + show + field
         patterns |= single_obj + field + show
         patterns |= obj("+") + obj_in_col("?") + show + obj_in_col("?") + field("?")
@@ -3628,6 +3629,11 @@ class Show(Command):
             elif isinstance(o, FieldType):
                 print "%s" % o.describe()
                 return
+            elif isinstance(o, Collection):
+                getter = app.reflect(o.getter)
+                obj = getter()
+                ref = o.element_type(obj)
+                object_chain.append(ref)
 
         alias_chain = aliases.add(*object_chain)
         ref = object_chain.pop()
@@ -3822,10 +3828,9 @@ class Install(Command):
 
         object_chain = []
 
-        attr = app.attrs()['license']
         install = app.reflect(collection.install_method)
         obj = install(file)
-        ref = attr.element_type(obj)
+        ref = collection.element_type(obj)
 
         if isinstance(ref, ObjectType):
             object_chain.append(ref)
@@ -3837,65 +3842,6 @@ class Install(Command):
             print "%s %s %s" % (ref.type_name(), alias, ref.describe())
         else:
             print "%s %s" % (ref.type_name(), ref.describe())
-
-class Status(Command):
-    """status - Shows the status of the specified object
-
-    Usage: status <TYPE>
-           <TYPE> status
-
-    Example:
-           status license
-           license status
-    """
-
-    def patterns(self):
-        status = Verb('status', partial_match = False, set_command = self)
-        col_type = CollectionByType()
-
-        patterns = status + col_type
-        patterns |= col_type + status
-        return patterns
-
-    def help(self):
-        print self.__doc__
-
-    def name(self):
-        return 'status'
-
-    def do(self, tokens):
-        assert(len(tokens) == 2)
-        collection = None
-        for tok in tokens:
-            if isinstance(tok, Collection):
-                collection = tok
-        assert(collection is not None)
-
-        if collection is None:
-            raise Exception("Bug in command pattern definition.")
-
-        if not collection.status_method:
-            raise Exception("Checking the status for elements of this type is"
-                            "not possible");
-
-        object_chain = []
-
-        attr = app.attrs()['license_status']
-        status = app.reflect(collection.status_method)
-        obj = status()
-        ref = attr.element_type(obj)
-
-        if isinstance(ref, ObjectType):
-            object_chain.append(ref)
-
-        alias_chain = aliases.add(*object_chain)
-
-        if alias_chain:
-            alias = alias_chain.pop()
-            print "%s %s %s" % (ref.type_name(), alias, ref.describe())
-        else:
-            print "%s %s" % (ref.type_name(), ref.describe())
-
 
 ################################################################################
 # Autocomplete cache
@@ -3951,8 +3897,7 @@ class MidonetCLI(cmd.Cmd):
         cmd.Cmd.__init__(self)
         self._root = root
         self._ops = [Show(), List(), Create(), Delete(), Set(), Clear(),
-                     Describe(), Debug(), PushTenant(), PopTenant(), Install(),
-                     Status()]
+                     Describe(), Debug(), PushTenant(), PopTenant(), Install()]
         for op in self._ops:
             if op.name() is not None:
                 setattr(self, "help_%s" % op.name(), op.help)

--- a/src/midonetclient/api.py
+++ b/src/midonetclient/api.py
@@ -545,9 +545,9 @@ class MidonetApi(object):
         self._ensure_application()
         return self.app.get_license(id_)
 
-    def status_license(self):
+    def get_license_status(self):
         self._ensure_application()
-        return self.app.status_license()
+        return self.app.get_license_status()
 
 # just for testing
 if __name__ == '__main__':

--- a/src/midonetclient/api.py
+++ b/src/midonetclient/api.py
@@ -533,6 +533,21 @@ class MidonetApi(object):
                 self.app = None
                 raise
 
+    def install_license(self, file):
+        self._ensure_application()
+        return self.app.install_license(file)
+
+    def get_licenses(self):
+        self._ensure_application()
+        return self.app.get_licenses()
+
+    def get_license(self, id_):
+        self._ensure_application()
+        return self.app.get_license(id_)
+
+    def status_license(self):
+        self._ensure_application()
+        return self.app.status_license()
 
 # just for testing
 if __name__ == '__main__':

--- a/src/midonetclient/api_lib.py
+++ b/src/midonetclient/api_lib.py
@@ -89,3 +89,31 @@ def do_request(uri, method, body=None, query=None, headers=None):
                                             err))
         raise err
     return response, from_json(content)
+
+def do_upload(uri, body=None, query=None, headers=None):
+    """Processes an HTTP POST request with a binary input and output JSON.
+    Returns a 2-tuple made of HTTP response, and content deserialized into an
+    object.
+    """
+
+    LOG.debug("do upload: uri=%s" % uri)
+    LOG.debug("do upload: body=%r" % len(body))
+    LOG.debug("do upload: headers=%s" % headers)
+
+    try:
+        response, content = httplib2.Http().request(uri, 'POST', body,
+                                                    headers=headers)
+    except socket_error as serr:
+        if serr[1] == "ECONNREFUSED":
+            raise exc.MidoApiConnectionRefused()
+        raise
+
+    if is_http_error(response['status']):
+        err = http_errors[response['status']](content)
+        LOG.error("Got HTTP error(response=%r content=%r) for "
+                  "request(uri=%r, body=%r, query=%r, headers=%r)."
+                  "Raising exception=%r" % (response, content,
+                                            uri, body, query, headers,
+                                            err))
+        raise err
+    return response, from_json(content)

--- a/src/midonetclient/application.py
+++ b/src/midonetclient/application.py
@@ -504,7 +504,7 @@ class Application(ResourceBase):
         return self._get_resource_by_id(License, None,
                                         self.dto['licenseTemplate'], id_)
 
-    def status_license(self):
+    def get_license_status(self):
         return self._get_resource(LicenseStatus, None,
                                   self.dto['licenseStatus'])
 

--- a/src/midonetclient/application.py
+++ b/src/midonetclient/application.py
@@ -19,6 +19,7 @@
 # @author: Ryu Ishimoto <ryu@midokura.com>, Midokura
 # @author: Artem Dmytrenko <art@midokura.com>, Midokura
 
+import os
 from midonetclient import vendor_media_type
 from midonetclient.ad_route import AdRoute
 from midonetclient.bgp import Bgp
@@ -44,7 +45,8 @@ from midonetclient.pool_member import PoolMember
 from midonetclient.health_monitor import HealthMonitor
 from midonetclient.pool_statistic import PoolStatistic
 from midonetclient.vtep import Vtep
-
+from midonetclient.license import License
+from midonetclient.license_status import LicenseStatus
 
 class Application(ResourceBase):
 
@@ -357,6 +359,10 @@ class Application(ResourceBase):
                                              ip_address)
         self.auth.do_request(uri, 'DELETE')
 
+    def _upload_resource(self, clazz, create_uri, uri, body, headers):
+        return clazz(create_uri, {'uri': uri}, self.auth)\
+            .upload(create_uri, body, headers=headers)
+
     #L4LB resources
     def get_load_balancers(self, query):
         headers = {'Accept':
@@ -481,3 +487,24 @@ class Application(ResourceBase):
     def delete_vtep(self, mgmt_ip):
         return self._delete_resource_by_ip_addr(self.get_vtep_template(),
                                                 mgmt_ip)
+
+    def install_license(self, file):
+        body = open(file.value, 'rb').read()
+        headers = {'Accept': vendor_media_type.APPLICATION_LICENSE_JSON_V1,
+                   'Content-Type': vendor_media_type.APPLICATION_OCTET_STREAM}
+        uri = self.dto['licenses']
+        return self._upload_resource(License, uri, None, body, headers)
+
+    def get_licenses(self):
+        headers = {'Accept':
+                   vendor_media_type.APPLICATION_LICENSE_COLLECTION_JSON_V1}
+        return self.get_children(self.dto['licenses'], {}, headers, License)
+
+    def get_license(self, id_):
+        return self._get_resource_by_id(License, None,
+                                        self.dto['licenseTemplate'], id_)
+
+    def status_license(self):
+        return self._get_resource(LicenseStatus, None,
+                                  self.dto['licenseStatus'])
+

--- a/src/midonetclient/auth_lib.py
+++ b/src/midonetclient/auth_lib.py
@@ -108,3 +108,22 @@ class Auth:
             self.set_header_token(headers, force=True)
             return api_lib.do_request(uri, method, body=body, query=query,
                                       headers=headers)
+
+    def do_upload(self, uri, body=None, query=None, headers=None):
+        ''' Wrapper for api_lib.do_upload that includes auth logic.
+        '''
+        query = query or dict()
+        headers = headers or dict()
+
+        # Username will be None if user has opted to skip authorization.
+        if self.username is not None:
+            self.set_header_token(headers)
+        try:
+            return api_lib.do_upload(uri, body=body, query=query,
+                                     headers=headers)
+        except exc.HTTPUnauthorized:
+            # Try one more time after logging in
+            LOG.info("Got HTTPUnauthorized error, try logging in again")
+            self.set_header_token(headers, force=True)
+            return api_lib.do_upload(uri, body=body, query=query,
+                                     headers=headers)

--- a/src/midonetclient/license.py
+++ b/src/midonetclient/license.py
@@ -1,0 +1,58 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2014 Midokura SARL.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# @author: Alex Bikfalvi <alex.bikfalvi@midokura.com>, Midokura
+
+from midonetclient import vendor_media_type
+from midonetclient.resource_base import ResourceBase
+
+class License(ResourceBase):
+
+    media_type = vendor_media_type.APPLICATION_LICENSE_JSON_V1
+
+    def __init__(self, uri, dto, auth):
+        super(License, self).__init__(uri, dto, auth)
+
+    def get_id(self):
+        return self.dto['id']
+
+    def get_issuer(self):
+        return self.dto['issuerX500']
+
+    def get_holder(self):
+        return self.dto['holderX500']
+
+    def get_issue_date(self):
+        return self.dto['issueDate']
+
+    def get_start_date(self):
+        return self.dto['startDate']
+
+    def get_end_date(self):
+        return self.dto['endDate']
+
+    def get_product(self):
+        return self.dto['product']
+
+    def get_description(self):
+        return self.dto['description']
+
+    def get_agent_quota(self):
+        return self.dto['extra']['agentQuota']
+
+    def is_valid(self):
+        return self.dto['valid']

--- a/src/midonetclient/license_status.py
+++ b/src/midonetclient/license_status.py
@@ -1,0 +1,34 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2014 Midokura SARL.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# @author: Alex Bikfalvi <alex.bikfalvi@midokura.com>, Midokura
+
+from midonetclient import vendor_media_type
+from midonetclient.resource_base import ResourceBase
+
+class LicenseStatus(ResourceBase):
+
+    media_type =  vendor_media_type.APPLICATION_LICENSE_STATUS_JSON_V1
+
+    def __init__(self, uri, dto, auth):
+        super(LicenseStatus, self).__init__(uri, dto, auth)
+
+    def is_valid(self):
+        return self.dto['valid']
+
+    def get_message(self):
+        return self.dto['message']

--- a/src/midonetclient/resource_base.py
+++ b/src/midonetclient/resource_base.py
@@ -50,6 +50,17 @@ class ResourceBase(object):
                                              headers=headers)
         return self
 
+    def upload(self, uri, body, headers=None):
+        """ Does REST POST with a binary body at some URI """
+
+        headers = headers or dict()
+        self._ensure_content_type(headers)
+
+        resp, self.dto = self.auth.do_upload(uri, body=body, headers=headers)
+        self._ensure_accept(headers)
+
+        return self
+
     def get(self, headers=None, **kwargs):
         """Does REST GET at some uri"""
         headers = headers or dict()

--- a/src/midonetclient/vendor_media_type.py
+++ b/src/midonetclient/vendor_media_type.py
@@ -171,7 +171,7 @@ APPLICATION_VTEP_BINDING_COLLECTION_JSON = \
 APPLICATION_LICENSE_JSON_V1 = \
             "application/vnd.org.midonet.License-v1+json"
 APPLICATION_LICENSE_COLLECTION_JSON_V1 = \
-            "application/vnd.org.midonet.LicenseList-v1+json"
+            "application/vnd.org.midonet.collection.License-v1+json"
 APPLICATION_LICENSE_STATUS_JSON_V1 = \
             "application/vnd.org.midonet.LicenseStatus-v1+json"
 

--- a/src/midonetclient/vendor_media_type.py
+++ b/src/midonetclient/vendor_media_type.py
@@ -17,8 +17,9 @@
 #
 # @author: Tomoe Sugihara <tomoe@midokura.com>, Midokura
 # @author: Ryu Ishimoto <ryu@midokura.com>, Midokura
+# @author: Alex Bikfalvi <alex.bikfalvi@midokura.com>, Midokura
 
-
+APPLICATION_OCTET_STREAM = "application/octet-stream";
 APPLICATION_JSON_V5 = "application/vnd.org.midonet.Application-v5+json"
 APPLICATION_ERROR_JSON = "application/vnd.org.midonet.Error-v1+json"
 APPLICATION_TENANT_JSON = "application/vnd.org.midonet.Tenant-v1+json"
@@ -165,3 +166,12 @@ APPLICATION_VTEP_COLLECTION_JSON = \
 APPLICATION_VTEP_BINDING_JSON = "application/vnd.org.midonet.VTEPBinding-v1+json"
 APPLICATION_VTEP_BINDING_COLLECTION_JSON = \
             "application/vnd.org.midonet.collection.VTEPBinding-v1+json"
+
+# License
+APPLICATION_LICENSE_JSON_V1 = \
+            "application/vnd.org.midonet.License-v1+json"
+APPLICATION_LICENSE_COLLECTION_JSON_V1 = \
+            "application/vnd.org.midonet.LicenseList-v1+json"
+APPLICATION_LICENSE_STATUS_JSON_V1 = \
+            "application/vnd.org.midonet.LicenseStatus-v1+json"
+


### PR DESCRIPTION
Adds the following object types to the CLI:
- License to show the information for a license bean
- LicenseStatus to show the information for the license
  status

Adds the following commands to the CLI:
- Install to allow the installation of a license object
  from a file
- Status to show the status of an object type, such as
  a license

Includes support for a POST method to the MidoNet API,
where the request media type is binary data (octet stream).

Signed-off-by: Alex Bikfalvi alex.bikfalvi@midokura.com
