### PR TITLE
Change Pools to be able to clear healthMonitor property

### DIFF
--- a/doc/midonet-cli-health-monitor.1.ronn
+++ b/doc/midonet-cli-health-monitor.1.ronn
@@ -44,6 +44,8 @@ A health monitor has these attributes:
     Timeout value for the health check in seconds.
   * `max-retries` [!]<INTEGER>
     Number of times to retry for health check.
+  * `type` [!] `TCP`
+    A type of the health monitor checking protocol.
 
 ## COPYRIGHT
 

--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -2060,7 +2060,8 @@ class Pool(ObjectType):
         self.put_attr(SingleAttr(name = 'health-monitor',
                                  value_type = ObjectRef('health-monitor'),
                                  getter = 'get_health_monitor_id',
-                                 setter = 'health_monitor_id'))
+                                 setter = 'health_monitor_id',
+                                 unsetter = 'health_monitor_id'))
         self.put_attr(EnumAttr(name = 'lb-method',
                                mappings = {'ROUND_ROBIN': 'ROUND_ROBIN'},
                                getter = 'get_lb_method',


### PR DESCRIPTION
This resolves MN-2375.

Tested manually. 503 is OK because the request was made correctly. The mapping between the health monitor and the pool is being processed (PENDING_CREATE) should be resolved when the connection between the health monitor and HA proxy is established.

``` bash
midonet> list router
midonet> health-monitor create delay 100 max-retries 50 timeout 500 type TCP
hm0
midonet> load-balancer create 
lb0
midonet> load-balancer lb0 create pool 
health-monitor  id  lb-method  load-balancer  protocol  state
midonet> load-balancer lb0 create pool 
health-monitor  id  lb-method  load-balancer  protocol  state
midonet> load-balancer lb0 create pool lb-method ROUND_ROBIN protocol TCP 
lb0:pool0
midonet> load-balancer lb0 pool pool0 set health-monitor hm0
midonet> load-balancer lb0 pool pool0 clear health-monitor 
Internal error: {"message":"The mapping between the health monitor and the pool is being processed (PENDING_CREATE).","code":503}
```
