### PR TITLE
Hides the vlan attribute for a VxLAN port.

### DIFF
--- a/src/midonetclient/port.py
+++ b/src/midonetclient/port.py
@@ -1,5 +1,3 @@
-# vim: tabstop=4 shiftwidth=4 softtabstop=4
-
 # Copyright 2013 Midokura PTE LTD.
 # All Rights Reserved
 #
@@ -25,6 +23,9 @@ from midonetclient import bgp
 from midonetclient import port_group_port
 from midonetclient.admin_state_up_mixin import AdminStateUpMixin
 from vendor_media_type import APPLICATION_PORTGROUP_PORT_COLLECTION_JSON
+
+
+PORT_TYPE_VXLAN = 'Vxlan'
 
 
 class Port(resource_base.ResourceBase, AdminStateUpMixin):
@@ -59,6 +60,8 @@ class Port(resource_base.ResourceBase, AdminStateUpMixin):
         return self.dto['interfaceName']
 
     def get_vlan_id(self):
+        if self.dto['type'] == PORT_TYPE_VXLAN:
+            return None
         return self.dto['vlanId']
 
     def get_peer_id(self):


### PR DESCRIPTION
The Vlan ID is not part of the original bridge port attributes. The
current CLI shows "VLAN: -1" for a VxLAN port when we list ports for a
bridge with a VxLAN port, which is useless and misleading. This patch
hides the Vlan attribute for a VxLAN port.

**Old CLI output**
midonet> bridge bridge5 list port
port port0 device bridge5 state up vlan -1 management-ip 119.15.112.22 vni 12304763

**New CLI output**
midonet> bridge bridge5 list port
port port0 device bridge5 state up management-ip 119.15.112.22 vni 12304763

Fix MN-2386
