### PR TITLE
Replace VTEP's tunnel-zone-id property with tunnel-zone ObjectRef.

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -2230,8 +2230,8 @@ class Vtep(ObjectType):
                                  value_type = L4PortNumber(),
                                  getter = 'get_management_port',
                                  setter = 'management_port'))
-        self.put_attr(SingleAttr(name = 'tunnel-zone-id',
-                                 value_type = UUID(),
+        self.put_attr(SingleAttr(name = 'tunnel-zone',
+                                 value_type = ObjectRef('tunnel-zone'),
                                  getter = 'get_tunnel_zone_id',
                                  setter = 'tunnel_zone_id'))
         self.put_attr(SingleAttr(name = 'connection-state',


### PR DESCRIPTION
This allows users to specify a tunnel zone by alias rather than by
typing out the tunnel zone's UUID.

Signed-off-by: Brandon Berg bberg@midokura.jp
