### PR TITLE
Revert "Clean up unused / duplicate imports, etc."

### DIFF
--- a/src/midonetclient/api.py
+++ b/src/midonetclient/api.py
@@ -20,6 +20,7 @@
 # @author: Artem Dmytrenko <art@midokura.com>, Midokura
 
 import logging
+from socket import error as socket_error
 
 from midonetclient import auth_lib
 from midonetclient.application import Application
@@ -412,13 +413,13 @@ class MidonetApi(object):
             port.unlink()
             self.delete_port(peer_id)
 
-    def add_router_route(self, router, route_type='Normal',
+    def add_router_route(self, router, type='Normal',
                          src_network_addr=None, src_network_length=None,
                          dst_network_addr=None, dst_network_length=None,
                          next_hop_port=None, next_hop_gateway=None,
                          weight=100):
         """Add a route to a router."""
-        route = router.add_route().type(route_type)
+        route = router.add_route().type(type)
         route = route.src_network_addr(src_network_addr).src_network_length(
             src_network_length).dst_network_addr(
                 dst_network_addr).dst_network_length(dst_network_length)
@@ -549,6 +550,7 @@ class MidonetApi(object):
 if __name__ == '__main__':
 
     import uuid
+    import time
     import sys
 
     if len(sys.argv) < 4:

--- a/src/midonetclient/bridge.py
+++ b/src/midonetclient/bridge.py
@@ -21,6 +21,7 @@
 
 from midonetclient import port_type
 from midonetclient import vendor_media_type
+from midonetclient.port import Port
 from midonetclient.dhcp_subnet import DhcpSubnet
 from midonetclient.port import Port
 from midonetclient.resource_base import ResourceBase
@@ -94,7 +95,7 @@ class Bridge(ResourceBase, AdminStateUpMixin):
             query = {}
         headers = {'Accept':
                    vendor_media_type.APPLICATION_PORT_V2_COLLECTION_JSON}
-        _, peer_ports = self.auth.do_request(self.dto['peerPorts'], 'GET',
+        res, peer_ports = self.auth.do_request(self.dto['peerPorts'], 'GET',
                                                headers=headers, query=query)
         res = []
         for pp in peer_ports:

--- a/src/midonetclient/rule.py
+++ b/src/midonetclient/rule.py
@@ -321,8 +321,8 @@ class Rule(ResourceBase):
         self.dto['tpDst'] = tp_dst
         return self
 
-    def type(self, rule_type):
-        self.dto['type'] = rule_type
+    def type(self, type):
+        self.dto['type'] = type
         return self
 
     def inv_dl_src(self, inv_dl_src):


### PR DESCRIPTION
This reverts commit cbd695a4451403aad7f4eff7cce2eaeff4256eb8.

The new naming of the argument "route_type" is incompatible with havana.

Signed-off-by: Joe Mills joe@midokura.com
