### PR TITLE
VTEP binding delete accepts only a single binding.

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -3553,10 +3553,12 @@ class Delete(Command):
 
     Examples:
            delete router router0 name 'new name for router'
+           delete vtep management-ip 192.168.0.1
+           delete vtep management-ip 192.168.0.1 binding vlan xxx
            router router0 port port0 delete
            router router0 delete port port0
+           vtep management-ip 192.168.0.1 delete
            vtep management-ip 192.168.0.1 delete binding vlan xxx
-           vtep management-ip 192.168.0.1 binding delete vlan xxx
     """
 
     def patterns(self):
@@ -3566,10 +3568,18 @@ class Delete(Command):
         col_type = CollectionByType()
 
         patterns = delete + obj("+") + obj_from_col("*")
+        # The below covers both
+        #   a. delete object-coll
+        #     -- c.f. delete vtep management-ip x.x.x.x
+        #   b. delete parent-object-coll child-object-coll
+        #     -- c.f. delete vtep management-ip x.x.x.x binding vlan Y ....
+        patterns |= delete + obj_from_col("+")
         patterns |= obj("+") + delete + obj("*") + obj_from_col("*")
         patterns |= obj("+") + obj_from_col("*") + delete + obj_from_col("*")
-        patterns |= obj_from_col("+") + delete + col_type + ListFilter()("+")
-        patterns |= obj_from_col("+") + col_type + delete + ListFilter()("+")
+        # E.g.
+        #   vtep management-ip x.x.x.x delete
+        #   vtep management-ip x.x.x.x delete binding vlan Y ....
+        patterns |= obj_from_col("+") + delete + obj_from_col("*")
         return patterns
 
     def help(self):
@@ -3581,21 +3591,11 @@ class Delete(Command):
     def do(self, tokens):
         assert(len(tokens) >= 2)
         obj = None
-        collection = None
-        list_filter = []
         for tok in tokens:
             if isinstance(tok, ObjectType):
                 obj = tok
-            elif isinstance(tok, Collection):
-                collection = tok
-            elif isinstance(tok, list):
-                list_filter = tok
         assert(obj is not None)
-        if collection:
-            for o in obj.fetch_all_for_type(collection.name, list_filter):
-                o.object().delete()
-        else:
-            obj.object().delete()
+        obj.object().delete()
 
 
 class Show(Command):


### PR DESCRIPTION
This fixes the issue with the previous VTEP binding deletion patch
that it allowed the user to delete multipe VTEP bindings at once,
which is not consistent with the existing deletion semantics. This
patch enforces the uniqueness of the binding deletion by reusing the
ObjectFromCollection construct. It also extends the accepted deletion
expressions to include "delete PARENT-COLLECTION CHILD-COLLECTION".

Fix MN-1824
