### PR TITLE
Show the license warning upon startup if MN not licensed

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -2322,7 +2322,7 @@ class LicenseStatus(ObjectType):
                                  getter = 'get_message'))
 
     def type_name(self):
-        return "license_status"
+        return "license-status"
 
 def _port_resolver(port):
     # This function dispatches the appropriate port class depending on the
@@ -2429,7 +2429,7 @@ class Midonet(ObjectType):
                                  list_method = 'get_licenses',
                                  getter = 'get_license',
                                  install_method = 'install_license'))
-        self.put_attr(Collection(name = 'license_status',
+        self.put_attr(Collection(name = 'license-status',
                                  element_type = LicenseStatus,
                                  list_method = None,
                                  getter = 'get_license_status'))
@@ -4103,8 +4103,10 @@ if __name__ == '__main__':
         root = session.connect()
         try:
             # Test the credential by making an API call first before starting a
-            # command loop.
-            root.get_tunnel_zones()
+            # command loop, and validate the current license status.
+            status = root.get_license_status()
+            if not status.is_valid():
+                sys.stdout.write("LICENSE WARNING: %s\n" % status.get_message())
         # Those except clauses are duplicitous. Cf. MidontCLI.default().
         except exc.HTTPUnauthorized as err:
             sys.stderr.write("Invalid credential. Wrong username/password. "


### PR DESCRIPTION
This changes verifies at the CLI startup the current license
status, and if the valid flag is false, it displays a warning
message to the user with the license status message.

This patch also fixes a minor inconsisteny in the naming
of the license status object type: license_status > license-status

Ref: MN-2498

Signed-off-by: Alex Bikfalvi alex.bikfalvi@midokura.com
