### PR TITLE
VxGW: backport Phase 1 commits

### DIFF
--- a/doc/midonet-cli-bridge.1.ronn
+++ b/doc/midonet-cli-bridge.1.ronn
@@ -62,6 +62,8 @@ Attributes:
   * `outfilter` <CHAIN>
   * `vlan` <VLAN_ID>
   * `peer` <PORT>
+  * `management-ip` <IP_ADDRESS> (only for a VXLAN port)
+  * `vni` <INTEGER> (only for a VXLAN port)
 
 ## COPYRIGHT
 

--- a/doc/midonet-cli-host.1.ronn
+++ b/doc/midonet-cli-host.1.ronn
@@ -21,7 +21,7 @@ A host has these attributes:
 
   * `name` <STRING>
   * `alive` <BOOLEAN>
-  * `addreses` <IP_ADDRESS[,IP_ADRESS...]>
+  * `addreses` <IP_ADDRESS[,IP_ADDRESS...]>
 
 It contains these subcollections of elements:
 

--- a/doc/midonet-cli-vtep.1.ronn
+++ b/doc/midonet-cli-vtep.1.ronn
@@ -1,0 +1,49 @@
+midonet-cli-vtep(1) -- VTEP objects in midonet-cli
+======================================================
+
+## SYNOPSIS
+
+    midonet> vtep list
+    midonet> vtep create management-ip 192.168.2.4 management-port 6632 tunnel-zone tzone0
+    midonet> vtep management-ip 192.168.2.4 show name
+    midonet> vtep management-ip 192.168.2.4 delete
+    midonet> vtep management-ip 192.168.2.4 list binding
+    midonet> vtep management-ip 192.168.2.4 add binding physical-port in1 vlan 142 network-id 5806710a-633b-49e8-86ff-203b2cca8089
+    midonet> vtep management-ip 192.168.2.4 delete binding physical-port in1 vlan 142 network-id 5806710a-633b-49e8-86ff-203b2cca8089
+
+
+## DESCRIPTION
+
+VTEP (VXLAN Tunnel End Point) represents a physical switch that exists in an external network.
+
+## ATTRIBUTES
+
+A VTEP has these attributes:
+
+  * `management-ip` <IP_ADDRESS>
+  * `management-port` <INTEGER>
+  * `name` <STRING>
+  * `tunnel-zone` <UUID> | [TUNNEL ZONE]
+  * `description` <STRING>
+
+NOTE: `name` and `description` are read-only attributes that are set by the system, and cannot be specified in a `vtep create` command or otherwise ignored.
+
+It contains the following sub-collection of bindings of VTEPs to Neutron networks / MidoNet Bridges:
+
+  * `binding` (see [VTEP BINDINGS][] below)
+
+## VTEP BINDINGS
+
+Attributes:
+
+  * `physical-port` <STRING>
+  * `vlan` <INTEGER>
+  * `network-id` <UUID>
+
+## COPYRIGHT
+
+Copyright (c) 2014 Midokura SARL, All Rights Reserved.
+
+## SEE ALSO
+
+midonet-cli(1)

--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -2219,13 +2219,12 @@ class Vtep(ObjectType):
         self.clear_attrs()
         self.put_attr(SingleAttr(name = 'name',
                                  value_type = StringType(),
-                                 setter = '',
+                                 setter = 'name',
                                  getter = 'get_name'))
-        # Description field is not implemented.
-        #self.put_attr(SingleAttr(name = 'description',
-        #                         value_type = StringType(),
-        #                         setter = 'description',
-        #                         getter = 'get_description'))
+        self.put_attr(SingleAttr(name = 'description',
+                                 value_type = StringType(),
+                                 setter = 'description',
+                                 getter = 'get_description'))
         self.put_attr(SingleAttr(name = 'management-ip',
                                  value_type = IPv4Address(),
                                  getter = 'get_management_ip',
@@ -2234,8 +2233,8 @@ class Vtep(ObjectType):
                                  value_type = L4PortNumber(),
                                  getter = 'get_management_port',
                                  setter = 'management_port'))
-        self.put_attr(SingleAttr(name = 'tunnel-zone-id',
-                                 value_type = UUID(),
+        self.put_attr(SingleAttr(name = 'tunnel-zone',
+                                 value_type = ObjectRef('tunnel-zone'),
                                  getter = 'get_tunnel_zone_id',
                                  setter = 'tunnel_zone_id'))
         self.put_attr(SingleAttr(name = 'connection-state',
@@ -3557,10 +3556,12 @@ class Delete(Command):
 
     Examples:
            delete router router0 name 'new name for router'
+           delete vtep management-ip 192.168.0.1
+           delete vtep management-ip 192.168.0.1 binding vlan xxx
            router router0 port port0 delete
            router router0 delete port port0
+           vtep management-ip 192.168.0.1 delete
            vtep management-ip 192.168.0.1 delete binding vlan xxx
-           vtep management-ip 192.168.0.1 binding delete vlan xxx
     """
 
     def patterns(self):
@@ -3570,10 +3571,18 @@ class Delete(Command):
         col_type = CollectionByType()
 
         patterns = delete + obj("+") + obj_from_col("*")
+        # The below covers both
+        #   a. delete object-coll
+        #     -- c.f. delete vtep management-ip x.x.x.x
+        #   b. delete parent-object-coll child-object-coll
+        #     -- c.f. delete vtep management-ip x.x.x.x binding vlan Y ....
+        patterns |= delete + obj_from_col("+")
         patterns |= obj("+") + delete + obj("*") + obj_from_col("*")
         patterns |= obj("+") + obj_from_col("*") + delete + obj_from_col("*")
-        patterns |= obj_from_col("+") + delete + col_type + ListFilter()("+")
-        patterns |= obj_from_col("+") + col_type + delete + ListFilter()("+")
+        # E.g.
+        #   vtep management-ip x.x.x.x delete
+        #   vtep management-ip x.x.x.x delete binding vlan Y ....
+        patterns |= obj_from_col("+") + delete + obj_from_col("*")
         return patterns
 
     def help(self):
@@ -3585,21 +3594,11 @@ class Delete(Command):
     def do(self, tokens):
         assert(len(tokens) >= 2)
         obj = None
-        collection = None
-        list_filter = []
         for tok in tokens:
             if isinstance(tok, ObjectType):
                 obj = tok
-            elif isinstance(tok, Collection):
-                collection = tok
-            elif isinstance(tok, list):
-                list_filter = tok
         assert(obj is not None)
-        if collection:
-            for o in obj.fetch_all_for_type(collection.name, list_filter):
-                o.object().delete()
-        else:
-            obj.object().delete()
+        obj.object().delete()
 
 
 class Show(Command):


### PR DESCRIPTION
Including the following from master:

b72cdc6 - A man page for VTEP.
f187556 - Fix a typo in the CLI man page for host command.
35aae3f - Implements VTEP-add CLI.
98dd72a - VTEP binding delete accepts only a single binding.
c4fd94d - Replace VTEP's tunnel-zone-id property with tunnel-zone ObjectRef.

Signed-off-by: Galo Navarro galo@midokura.com
