### PR TITLE
Adds support for a VTEP tunnel zone type

### DIFF
--- a/src/bin/midonet-cli
+++ b/src/bin/midonet-cli
@@ -1348,7 +1348,8 @@ class TunnelZone(ObjectType):
                                  setter = 'name'))
         self.put_attr(EnumAttr(name = 'type',
                                mappings = {'gre': 'gre',
-                                           'vxlan': 'vxlan'},
+                                           'vxlan': 'vxlan',
+                                           'vtep': 'vtep'},
                                getter = 'get_type',
                                setter = 'type',
                                optional = False))

--- a/src/midonetclient/tunnel_zone.py
+++ b/src/midonetclient/tunnel_zone.py
@@ -40,6 +40,8 @@ class TunnelZone(ResourceBase):
             return vendor_media_type.APPLICATION_GRE_TUNNEL_ZONE_HOST_JSON
         elif self.dto['type'] == 'vxlan':
             return vendor_media_type.APPLICATION_TUNNEL_ZONE_HOST_JSON
+        elif self.dto['type'] == 'vtep':
+            return vendor_media_type.APPLICATION_TUNNEL_ZONE_HOST_JSON
 
     def _get_tunnel_zone_host_list_media_type(self):
         if self.tunnel_zone_host_list_media_type:
@@ -49,6 +51,10 @@ class TunnelZone(ResourceBase):
                 APPLICATION_GRE_TUNNEL_ZONE_HOST_COLLECTION_JSON
 
         elif self.dto['type'] == 'vxlan':
+            return vendor_media_type.\
+                APPLICATION_TUNNEL_ZONE_HOST_COLLECTION_JSON
+
+        elif self.dto['type'] == 'vtep':
             return vendor_media_type.\
                 APPLICATION_TUNNEL_ZONE_HOST_COLLECTION_JSON
 


### PR DESCRIPTION
This patch adds support for a VTEP tunnel zone type,
for network topologies that need to configure a physical
VTEP.

Fixes: MN-2573

Signed-off-by: Alex Bikfalvi alex.bikfalvi@midokura.com
