### PR TITLE
Removes the VTEP name setter.

### DIFF
--- a/src/midonetclient/vtep.py
+++ b/src/midonetclient/vtep.py
@@ -45,10 +45,6 @@ class Vtep(ResourceBase):
     def get_tunnel_zone_id(self):
         return self.dto['tunnelZoneId']
 
-    def name(self, name):
-        self.dto['name'] = name
-        return self
-
     def description(self, desc):
         self.dto['description'] = desc
         return self


### PR DESCRIPTION
The VTEP name is always set by the system and not to be set by the
client. This patch removes the setter for the VTEP name from Python
MidoNet Client Vtep class.

Fix MN-2510
